### PR TITLE
Added standard formatting option to D&C json

### DIFF
--- a/doctrine-and-covenants-std-format.json
+++ b/doctrine-and-covenants-std-format.json
@@ -1,0 +1,18991 @@
+﻿{
+	"books": [{
+			"book": "D&C 1-25",
+			"chapters": [{
+					"chapter": 1,
+					"reference": "D&C 1",
+					"verses": [{
+							"reference": "D&C 1:1",
+							"text": "Hearken, O ye people of my church, saith the voice of him who dwells on high, and whose eyes are upon all men; yea, verily I say: Hearken ye people from afar; and ye that are upon the islands of the sea, listen together.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 1:2",
+							"text": "For verily the voice of the Lord is unto all men, and there is none to escape; and there is no eye that shall not see, neither ear that shall not hear, neither heart that shall not be penetrated.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 1:3",
+							"text": "And the rebellious shall be pierced with much sorrow; for their iniquities shall be spoken upon the housetops, and their secret acts shall be revealed.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 1:4",
+							"text": "And the voice of warning shall be unto all people, by the mouths of my disciples, whom I have chosen in these last days.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 1:5",
+							"text": "And they shall go forth and none shall stay them, for I the Lord have commanded them.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 1:6",
+							"text": "Behold, this is mine authority, and the authority of my servants, and my preface unto the book of my commandments, which I have given them to publish unto you, O inhabitants of the earth.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 1:7",
+							"text": "Wherefore, fear and tremble, O ye people, for what I the Lord have decreed in them shall be fulfilled.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 1:8",
+							"text": "And verily I say unto you, that they who go forth, bearing these tidings unto the inhabitants of the earth, to them is power given to seal both on earth and in heaven, the unbelieving and rebellious;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 1:9",
+							"text": "Yea, verily, to seal them up unto the day when the wrath of God shall be poured out upon the wicked without measure\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 1:10",
+							"text": "Unto the day when the Lord shall come to recompense unto every man according to his work, and measure to every man according to the measure which he has measured to his fellow man.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 1:11",
+							"text": "Wherefore the voice of the Lord is unto the ends of the earth, that all that will hear may hear:",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 1:12",
+							"text": "Prepare ye, prepare ye for that which is to come, for the Lord is nigh;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 1:13",
+							"text": "And the anger of the Lord is kindled, and his sword is bathed in heaven, and it shall fall upon the inhabitants of the earth.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 1:14",
+							"text": "And the arm of the Lord shall be revealed; and the day cometh that they who will not hear the voice of the Lord, neither the voice of his servants, neither give heed to the words of the prophets and apostles, shall be cut off from among the people;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 1:15",
+							"text": "For they have strayed from mine ordinances, and have broken mine everlasting covenant;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 1:16",
+							"text": "They seek not the Lord to establish his righteousness, but every man walketh in his own way, and after the image of his own god, whose image is in the likeness of the world, and whose substance is that of an idol, which waxeth old and shall perish in Babylon, even Babylon the great, which shall fall.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 1:17",
+							"text": "Wherefore, I the Lord, knowing the calamity which should come upon the inhabitants of the earth, called upon my servant Joseph Smith, Jun., and spake unto him from heaven, and gave him commandments;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 1:18",
+							"text": "And also gave commandments to others, that they should proclaim these things unto the world; and all this that it might be fulfilled, which was written by the prophets\u2014",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 1:19",
+							"text": "The weak things of the world shall come forth and break down the mighty and strong ones, that man should not counsel his fellow man, neither trust in the arm of flesh\u2014",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 1:20",
+							"text": "But that every man might speak in the name of God the Lord, even the Savior of the world;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 1:21",
+							"text": "That faith also might increase in the earth;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 1:22",
+							"text": "That mine everlasting covenant might be established;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 1:23",
+							"text": "That the fulness of my gospel might be proclaimed by the weak and the simple unto the ends of the world, and before kings and rulers.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 1:24",
+							"text": "Behold, I am God and have spoken it; these commandments are of me, and were given unto my servants in their weakness, after the manner of their language, that they might come to understanding.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 1:25",
+							"text": "And inasmuch as they erred it might be made known;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 1:26",
+							"text": "And inasmuch as they sought wisdom they might be instructed;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 1:27",
+							"text": "And inasmuch as they sinned they might be chastened, that they might repent;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 1:28",
+							"text": "And inasmuch as they were humble they might be made strong, and blessed from on high, and receive knowledge from time to time.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 1:29",
+							"text": "And after having received the record of the Nephites, yea, even my servant Joseph Smith, Jun., might have power to translate through the mercy of God, by the power of God, the Book of Mormon.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 1:30",
+							"text": "And also those to whom these commandments were given, might have power to lay the foundation of this church, and to bring it forth out of obscurity and out of darkness, the only true and living church upon the face of the whole earth, with which I, the Lord, am well pleased, speaking unto the church collectively and not individually\u2014",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 1:31",
+							"text": "For I the Lord cannot look upon sin with the least degree of allowance;",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 1:32",
+							"text": "Nevertheless, he that repents and does the commandments of the Lord shall be forgiven;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 1:33",
+							"text": "And he that repents not, from him shall be taken even the light which he has received; for my Spirit shall not always strive with man, saith the Lord of Hosts.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 1:34",
+							"text": "And again, verily I say unto you, O inhabitants of the earth: I the Lord am willing to make these things known unto all flesh;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 1:35",
+							"text": "For I am no respecter of persons, and will that all men shall know that the day speedily cometh; the hour is not yet, but is nigh at hand, when peace shall be taken from the earth, and the devil shall have power over his own dominion.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 1:36",
+							"text": "And also the Lord shall have power over his saints, and shall reign in their midst, and shall come down in judgment upon Idumea, or the world.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 1:37",
+							"text": "Search these commandments, for they are true and faithful, and the prophecies and promises which are in them shall all be fulfilled.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 1:38",
+							"text": "What I the Lord have spoken, I have spoken, and I excuse not myself; and though the heavens and the earth pass away, my word shall not pass away, but shall all be fulfilled, whether by mine own voice or by the voice of my servants, it is the same.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 1:39",
+							"text": "For behold, and lo, the Lord is God, and the Spirit beareth record, and the record is true, and the truth abideth forever and ever. Amen.",
+							"verse": 39
+						}
+					]
+				},
+				{
+					"chapter": 2,
+					"reference": "D&C 2",
+					"verses": [{
+							"reference": "D&C 2:1",
+							"text": "Behold, I will reveal unto you the Priesthood, by the hand of Elijah the prophet, before the coming of the great and dreadful day of the Lord.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 2:2",
+							"text": "And he shall plant in the hearts of the children the promises made to the fathers, and the hearts of the children shall turn to their fathers.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 2:3",
+							"text": "If it were not so, the whole earth would be utterly wasted at his coming.",
+							"verse": 3
+						}
+					]
+				},
+				{
+					"chapter": 3,
+					"reference": "D&C 3",
+					"verses": [{
+							"reference": "D&C 3:1",
+							"text": "The works, and the designs, and the purposes of God cannot be frustrated, neither can they come to naught.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 3:2",
+							"text": "For God doth not walk in crooked paths, neither doth he turn to the right hand nor to the left, neither doth he vary from that which he hath said, therefore his paths are straight, and his course is one eternal round.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 3:3",
+							"text": "Remember, remember that it is not the work of God that is frustrated, but the work of men;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 3:4",
+							"text": "For although a man may have many revelations, and have power to do many mighty works, yet if he boasts in his own strength, and sets at naught the counsels of God, and follows after the dictates of his own will and carnal desires, he must fall and incur the vengeance of a just God upon him.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 3:5",
+							"text": "Behold, you have been entrusted with these things, but how strict were your commandments; and remember also the promises which were made to you, if you did not transgress them.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 3:6",
+							"text": "And behold, how oft you have transgressed the commandments and the laws of God, and have gone on in the persuasions of men.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 3:7",
+							"text": "For, behold, you should not have feared man more than God. Although men set at naught the counsels of God, and despise his words\u2014",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 3:8",
+							"text": "Yet you should have been faithful; and he would have extended his arm and supported you against all the fiery darts of the adversary; and he would have been with you in every time of trouble.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 3:9",
+							"text": "Behold, thou art Joseph, and thou wast chosen to do the work of the Lord, but because of transgression, if thou art not aware thou wilt fall.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 3:10",
+							"text": "But remember, God is merciful; therefore, repent of that which thou hast done which is contrary to the commandment which I gave you, and thou art still chosen, and art again called to the work;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 3:11",
+							"text": "Except thou do this, thou shalt be delivered up and become as other men, and have no more gift.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 3:12",
+							"text": "And when thou deliveredst up that which God had given thee sight and power to translate, thou deliveredst up that which was sacred into the hands of a wicked man,",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 3:13",
+							"text": "Who has set at naught the counsels of God, and has broken the most sacred promises which were made before God, and has depended upon his own judgment and boasted in his own wisdom.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 3:14",
+							"text": "And this is the reason that thou hast lost thy privileges for a season\u2014",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 3:15",
+							"text": "For thou hast suffered the counsel of thy director to be trampled upon from the beginning.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 3:16",
+							"text": "Nevertheless, my work shall go forth, for inasmuch as the knowledge of a Savior has come unto the world, through the testimony of the Jews, even so shall the knowledge of a Savior come unto my people\u2014",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 3:17",
+							"text": "And to the Nephites, and the Jacobites, and the Josephites, and the Zoramites, through the testimony of their fathers\u2014",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 3:18",
+							"text": "And this testimony shall come to the knowledge of the Lamanites, and the Lemuelites, and the Ishmaelites, who dwindled in unbelief because of the iniquity of their fathers, whom the Lord has suffered to destroy their brethren the Nephites, because of their iniquities and their abominations.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 3:19",
+							"text": "And for this very purpose are these plates preserved, which contain these records\u2014that the promises of the Lord might be fulfilled, which he made to his people;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 3:20",
+							"text": "And that the Lamanites might come to the knowledge of their fathers, and that they might know the promises of the Lord, and that they may believe the gospel and rely upon the merits of Jesus Christ, and be glorified through faith in his name, and that through their repentance they might be saved. Amen.",
+							"verse": 20
+						}
+					]
+				},
+				{
+					"chapter": 4,
+					"reference": "D&C 4",
+					"verses": [{
+							"reference": "D&C 4:1",
+							"text": "Now behold, a marvelous work is about to come forth among the children of men.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 4:2",
+							"text": "Therefore, O ye that embark in the service of God, see that ye serve him with all your heart, might, mind and strength, that ye may stand blameless before God at the last day.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 4:3",
+							"text": "Therefore, if ye have desires to serve God ye are called to the work;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 4:4",
+							"text": "For behold the field is white already to harvest; and lo, he that thrusteth in his sickle with his might, the same layeth up in store that he perisheth not, but bringeth salvation to his soul;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 4:5",
+							"text": "And faith, hope, charity and love, with an eye single to the glory of God, qualify him for the work.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 4:6",
+							"text": "Remember faith, virtue, knowledge, temperance, patience, brotherly kindness, godliness, charity, humility, diligence.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 4:7",
+							"text": "Ask, and ye shall receive; knock, and it shall be opened unto you. Amen.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 5,
+					"reference": "D&C 5",
+					"verses": [{
+							"reference": "D&C 5:1",
+							"text": "Behold, I say unto you, that as my servant Martin Harris has desired a witness at my hand, that you, my servant Joseph Smith, Jun., have got the plates of which you have testified and borne record that you have received of me;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 5:2",
+							"text": "And now, behold, this shall you say unto him\u2014he who spake unto you, said unto you: I, the Lord, am God, and have given these things unto you, my servant Joseph Smith, Jun., and have commanded you that you should stand as a witness of these things;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 5:3",
+							"text": "And I have caused you that you should enter into a covenant with me, that you should not show them except to those persons to whom I commanded you; and you have no power over them except I grant it unto you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 5:4",
+							"text": "And you have a gift to translate the plates; and this is the first gift that I bestowed upon you; and I have commanded that you should pretend to no other gift until my purpose is fulfilled in this; for I will grant unto you no other gift until it is finished.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 5:5",
+							"text": "Verily, I say unto you, that woe shall come unto the inhabitants of the earth if they will not hearken unto my words;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 5:6",
+							"text": "For hereafter you shall be ordained and go forth and deliver my words unto the children of men.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 5:7",
+							"text": "Behold, if they will not believe my words, they would not believe you, my servant Joseph, if it were possible that you should show them all these things which I have committed unto you.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 5:8",
+							"text": "Oh, this unbelieving and stiffnecked generation\u2014mine anger is kindled against them.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 5:9",
+							"text": "Behold, verily I say unto you, I have reserved those things which I have entrusted unto you, my servant Joseph, for a wise purpose in me, and it shall be made known unto future generations;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 5:10",
+							"text": "But this generation shall have my word through you;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 5:11",
+							"text": "And in addition to your testimony, the testimony of three of my servants, whom I shall call and ordain, unto whom I will show these things, and they shall go forth with my words that are given through you.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 5:12",
+							"text": "Yea, they shall know of a surety that these things are true, for from heaven will I declare it unto them.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 5:13",
+							"text": "I will give them power that they may behold and view these things as they are;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 5:14",
+							"text": "And to none else will I grant this power, to receive this same testimony among this generation, in this the beginning of the rising up and the coming forth of my church out of the wilderness\u2014clear as the moon, and fair as the sun, and terrible as an army with banners.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 5:15",
+							"text": "And the testimony of three witnesses will I send forth of my word.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 5:16",
+							"text": "And behold, whosoever believeth on my words, them will I visit with the manifestation of my Spirit; and they shall be born of me, even of water and of the Spirit\u2014",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 5:17",
+							"text": "And you must wait yet a little while, for ye are not yet ordained\u2014",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 5:18",
+							"text": "And their testimony shall also go forth unto the condemnation of this generation if they harden their hearts against them;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 5:19",
+							"text": "For a desolating scourge shall go forth among the inhabitants of the earth, and shall continue to be poured out from time to time, if they repent not, until the earth is empty, and the inhabitants thereof are consumed away and utterly destroyed by the brightness of my coming.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 5:20",
+							"text": "Behold, I tell you these things, even as I also told the people of the destruction of Jerusalem; and my word shall be verified at this time as it hath hitherto been verified.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 5:21",
+							"text": "And now I command you, my servant Joseph, to repent and walk more uprightly before me, and to yield to the persuasions of men no more;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 5:22",
+							"text": "And that you be firm in keeping the commandments wherewith I have commanded you; and if you do this, behold I grant unto you eternal life, even if you should be slain.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 5:23",
+							"text": "And now, again, I speak unto you, my servant Joseph, concerning the man that desires the witness\u2014",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 5:24",
+							"text": "Behold, I say unto him, he exalts himself and does not humble himself sufficiently before me; but if he will bow down before me, and humble himself in mighty prayer and faith, in the sincerity of his heart, then will I grant unto him a view of the things which he desires to see.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 5:25",
+							"text": "And then he shall say unto the people of this generation: Behold, I have seen the things which the Lord hath shown unto Joseph Smith, Jun., and I know of a surety that they are true, for I have seen them, for they have been shown unto me by the power of God and not of man.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 5:26",
+							"text": "And I the Lord command him, my servant Martin Harris, that he shall say no more unto them concerning these things, except he shall say: I have seen them, and they have been shown unto me by the power of God; and these are the words which he shall say.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 5:27",
+							"text": "But if he deny this he will break the covenant which he has before covenanted with me, and behold, he is condemned.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 5:28",
+							"text": "And now, except he humble himself and acknowledge unto me the things that he has done which are wrong, and covenant with me that he will keep my commandments, and exercise faith in me, behold, I say unto him, he shall have no such views, for I will grant unto him no views of the things of which I have spoken.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 5:29",
+							"text": "And if this be the case, I command you, my servant Joseph, that you shall say unto him, that he shall do no more, nor trouble me any more concerning this matter.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 5:30",
+							"text": "And if this be the case, behold, I say unto thee Joseph, when thou hast translated a few more pages thou shalt stop for a season, even until I command thee again; then thou mayest translate again.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 5:31",
+							"text": "And except thou do this, behold, thou shalt have no more gift, and I will take away the things which I have entrusted with thee.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 5:32",
+							"text": "And now, because I foresee the lying in wait to destroy thee, yea, I foresee that if my servant Martin Harris humbleth not himself and receive a witness from my hand, that he will fall into transgression;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 5:33",
+							"text": "And there are many that lie in wait to destroy thee from off the face of the earth; and for this cause, that thy days may be prolonged, I have given unto thee these commandments.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 5:34",
+							"text": "Yea, for this cause I have said: Stop, and stand still until I command thee, and I will provide means whereby thou mayest accomplish the thing which I have commanded thee.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 5:35",
+							"text": "And if thou art faithful in keeping my commandments, thou shalt be lifted up at the last day. Amen.",
+							"verse": 35
+						}
+					]
+				},
+				{
+					"chapter": 6,
+					"reference": "D&C 6",
+					"verses": [{
+							"reference": "D&C 6:1",
+							"text": "A great and marvelous work is about to come forth unto the children of men.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 6:2",
+							"text": "Behold, I am God; give heed unto my word, which is quick and powerful, sharper than a two-edged sword, to the dividing asunder of both joints and marrow; therefore give heed unto my words.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 6:3",
+							"text": "Behold, the field is white already to harvest; therefore, whoso desireth to reap, let him thrust in his sickle with his might, and reap while the day lasts, that he may treasure up for his soul everlasting salvation in the kingdom of God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 6:4",
+							"text": "Yea, whosoever will thrust in his sickle and reap, the same is called of God.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 6:5",
+							"text": "Therefore, if you will ask of me you shall receive; if you will knock it shall be opened unto you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 6:6",
+							"text": "Now, as you have asked, behold, I say unto you, keep my commandments, and seek to bring forth and establish the cause of Zion;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 6:7",
+							"text": "Seek not for riches but for wisdom, and behold, the mysteries of God shall be unfolded unto you, and then shall you be made rich. Behold, he that hath eternal life is rich.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 6:8",
+							"text": "Verily, verily, I say unto you, even as you desire of me so it shall be unto you; and if you desire, you shall be the means of doing much good in this generation.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 6:9",
+							"text": "Say nothing but repentance unto this generation; keep my commandments, and assist to bring forth my work, according to my commandments, and you shall be blessed.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 6:10",
+							"text": "Behold thou hast a gift, and blessed art thou because of thy gift. Remember it is sacred and cometh from above\u2014",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 6:11",
+							"text": "And if thou wilt inquire, thou shalt know mysteries which are great and marvelous; therefore thou shalt exercise thy gift, that thou mayest find out mysteries, that thou mayest bring many to the knowledge of the truth, yea, convince them of the error of their ways.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 6:12",
+							"text": "Make not thy gift known unto any save it be those who are of thy faith. Trifle not with sacred things.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 6:13",
+							"text": "If thou wilt do good, yea, and hold out faithful to the end, thou shalt be saved in the kingdom of God, which is the greatest of all the gifts of God; for there is no gift greater than the gift of salvation.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 6:14",
+							"text": "Verily, verily, I say unto thee, blessed art thou for what thou hast done; for thou hast inquired of me, and behold, as often as thou hast inquired thou hast received instruction of my Spirit. If it had not been so, thou wouldst not have come to the place where thou art at this time.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 6:15",
+							"text": "Behold, thou knowest that thou hast inquired of me and I did enlighten thy mind; and now I tell thee these things that thou mayest know that thou hast been enlightened by the Spirit of truth;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 6:16",
+							"text": "Yea, I tell thee, that thou mayest know that there is none else save God that knowest thy thoughts and the intents of thy heart.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 6:17",
+							"text": "I tell thee these things as a witness unto thee\u2014that the words or the work which thou hast been writing are true.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 6:18",
+							"text": "Therefore be diligent; stand by my servant Joseph, faithfully, in whatsoever difficult circumstances he may be for the word's sake.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 6:19",
+							"text": "Admonish him in his faults, and also receive admonition of him. Be patient; be sober; be temperate; have patience, faith, hope and charity.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 6:20",
+							"text": "Behold, thou art Oliver, and I have spoken unto thee because of thy desires; therefore treasure up these words in thy heart. Be faithful and diligent in keeping the commandments of God, and I will encircle thee in the arms of my love.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 6:21",
+							"text": "Behold, I am Jesus Christ, the Son of God. I am the same that came unto mine own, and mine own received me not. I am the light which shineth in darkness, and the darkness comprehendeth it not.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 6:22",
+							"text": "Verily, verily, I say unto you, if you desire a further witness, cast your mind upon the night that you cried unto me in your heart, that you might know concerning the truth of these things.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 6:23",
+							"text": "Did I not speak peace to your mind concerning the matter? What greater witness can you have than from God?",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 6:24",
+							"text": "And now, behold, you have received a witness; for if I have told you things which no man knoweth have you not received a witness?",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 6:25",
+							"text": "And, behold, I grant unto you a gift, if you desire of me, to translate, even as my servant Joseph.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 6:26",
+							"text": "Verily, verily, I say unto you, that there are records which contain much of my gospel, which have been kept back because of the wickedness of the people;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 6:27",
+							"text": "And now I command you, that if you have good desires\u2014a desire to lay up treasures for yourself in heaven\u2014then shall you assist in bringing to light, with your gift, those parts of my scriptures which have been hidden because of iniquity.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 6:28",
+							"text": "And now, behold, I give unto you, and also unto my servant Joseph, the keys of this gift, which shall bring to light this ministry; and in the mouth of two or three witnesses shall every word be established.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 6:29",
+							"text": "Verily, verily, I say unto you, if they reject my words, and this part of my gospel and ministry, blessed are ye, for they can do no more unto you than unto me.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 6:30",
+							"text": "And even if they do unto you even as they have done unto me, blessed are ye, for you shall dwell with me in glory.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 6:31",
+							"text": "But if they reject not my words, which shall be established by the testimony which shall be given, blessed are they, and then shall ye have joy in the fruit of your labors.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 6:32",
+							"text": "Verily, verily, I say unto you, as I said unto my disciples, where two or three are gathered together in my name, as touching one thing, behold, there will I be in the midst of them\u2014even so am I in the midst of you.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 6:33",
+							"text": "Fear not to do good, my sons, for whatsoever ye sow, that shall ye also reap; therefore, if ye sow good ye shall also reap good for your reward.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 6:34",
+							"text": "Therefore, fear not, little flock; do good; let earth and hell combine against you, for if ye are built upon my rock, they cannot prevail.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 6:35",
+							"text": "Behold, I do not condemn you; go your ways and sin no more; perform with soberness the work which I have commanded you.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 6:36",
+							"text": "Look unto me in every thought; doubt not, fear not.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 6:37",
+							"text": "Behold the wounds which pierced my side, and also the prints of the nails in my hands and feet; be faithful, keep my commandments, and ye shall inherit the kingdom of heaven. Amen.",
+							"verse": 37
+						}
+					]
+				},
+				{
+					"chapter": 7,
+					"reference": "D&C 7",
+					"verses": [{
+							"reference": "D&C 7:1",
+							"text": "And the Lord said unto me: John, my beloved, what desirest thou? For if you shall ask what you will, it shall be granted unto you.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 7:2",
+							"text": "And I said unto him: Lord, give unto me power over death, that I may live and bring souls unto thee.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 7:3",
+							"text": "And the Lord said unto me: Verily, verily, I say unto thee, because thou desirest this thou shalt tarry until I come in my glory, and shalt prophesy before nations, kindreds, tongues and people.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 7:4",
+							"text": "And for this cause the Lord said unto Peter: If I will that he tarry till I come, what is that to thee? For he desired of me that he might bring souls unto me, but thou desiredst that thou mightest speedily come unto me in my kingdom.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 7:5",
+							"text": "I say unto thee, Peter, this was a good desire; but my beloved has desired that he might do more, or a greater work yet among men than what he has before done.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 7:6",
+							"text": "Yea, he has undertaken a greater work; therefore I will make him as flaming fire and a ministering angel; he shall minister for those who shall be heirs of salvation who dwell on the earth.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 7:7",
+							"text": "And I will make thee to minister for him and for thy brother James; and unto you three I will give this power and the keys of this ministry until I come.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 7:8",
+							"text": "Verily I say unto you, ye shall both have according to your desires, for ye both joy in that which ye have desired.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 8,
+					"reference": "D&C 8",
+					"verses": [{
+							"reference": "D&C 8:1",
+							"text": "Oliver Cowdery, verily, verily, I say unto you, that assuredly as the Lord liveth, who is your God and your Redeemer, even so surely shall you receive a knowledge of whatsoever things you shall ask in faith, with an honest heart, believing that you shall receive a knowledge concerning the engravings of old records, which are ancient, which contain those parts of my scripture of which has been spoken by the manifestation of my Spirit.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 8:2",
+							"text": "Yea, behold, I will tell you in your mind and in your heart, by the Holy Ghost, which shall come upon you and which shall dwell in your heart.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 8:3",
+							"text": "Now, behold, this is the spirit of revelation; behold, this is the spirit by which Moses brought the children of Israel through the Red Sea on dry ground.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 8:4",
+							"text": "Therefore this is thy gift; apply unto it, and blessed art thou, for it shall deliver you out of the hands of your enemies, when, if it were not so, they would slay you and bring your soul to destruction.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 8:5",
+							"text": "Oh, remember these words, and keep my commandments. Remember, this is your gift.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 8:6",
+							"text": "Now this is not all thy gift; for you have another gift, which is the gift of Aaron; behold, it has told you many things;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 8:7",
+							"text": "Behold, there is no other power, save the power of God, that can cause this gift of Aaron to be with you.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 8:8",
+							"text": "Therefore, doubt not, for it is the gift of God; and you shall hold it in your hands, and do marvelous works; and no power shall be able to take it away out of your hands, for it is the work of God.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 8:9",
+							"text": "And, therefore, whatsoever you shall ask me to tell you by that means, that will I grant unto you, and you shall have knowledge concerning it.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 8:10",
+							"text": "Remember that without faith you can do nothing; therefore ask in faith. Trifle not with these things; do not ask for that which you ought not.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 8:11",
+							"text": "Ask that you may know the mysteries of God, and that you may translate and receive knowledge from all those ancient records which have been hid up, that are sacred; and according to your faith shall it be done unto you.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 8:12",
+							"text": "Behold, it is I that have spoken it; and I am the same that spake unto you from the beginning. Amen.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 9,
+					"reference": "D&C 9",
+					"verses": [{
+							"reference": "D&C 9:1",
+							"text": "Behold, I say unto you, my son, that because you did not translate according to that which you desired of me, and did commence again to write for my servant, Joseph Smith, Jun., even so I would that ye should continue until you have finished this record, which I have entrusted unto him.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 9:2",
+							"text": "And then, behold, other records have I, that I will give unto you power that you may assist to translate.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 9:3",
+							"text": "Be patient, my son, for it is wisdom in me, and it is not expedient that you should translate at this present time.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 9:4",
+							"text": "Behold, the work which you are called to do is to write for my servant Joseph.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 9:5",
+							"text": "And, behold, it is because that you did not continue as you commenced, when you began to translate, that I have taken away this privilege from you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 9:6",
+							"text": "Do not murmur, my son, for it is wisdom in me that I have dealt with you after this manner.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 9:7",
+							"text": "Behold, you have not understood; you have supposed that I would give it unto you, when you took no thought save it was to ask me.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 9:8",
+							"text": "But, behold, I say unto you, that you must study it out in your mind; then you must ask me if it be right, and if it is right I will cause that your bosom shall burn within you; therefore, you shall feel that it is right.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 9:9",
+							"text": "But if it be not right you shall have no such feelings, but you shall have a stupor of thought that shall cause you to forget the thing which is wrong; therefore, you cannot write that which is sacred save it be given you from me.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 9:10",
+							"text": "Now, if you had known this you could have translated; nevertheless, it is not expedient that you should translate now.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 9:11",
+							"text": "Behold, it was expedient when you commenced; but you feared, and the time is past, and it is not expedient now;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 9:12",
+							"text": "For, do you not behold that I have given unto my servant Joseph sufficient strength, whereby it is made up? And neither of you have I condemned.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 9:13",
+							"text": "Do this thing which I have commanded you, and you shall prosper. Be faithful, and yield to no temptation.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 9:14",
+							"text": "Stand fast in the work wherewith I have called you, and a hair of your head shall not be lost, and you shall be lifted up at the last day. Amen.",
+							"verse": 14
+						}
+					]
+				},
+				{
+					"chapter": 10,
+					"reference": "D&C 10",
+					"verses": [{
+							"reference": "D&C 10:1",
+							"text": "Now, behold, I say unto you, that because you delivered up those writings which you had power given unto you to translate by the means of the Urim and Thummim, into the hands of a wicked man, you have lost them.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 10:2",
+							"text": "And you also lost your gift at the same time, and your mind became darkened.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 10:3",
+							"text": "Nevertheless, it is now restored unto you again; therefore see that you are faithful and continue on unto the finishing of the remainder of the work of translation as you have begun.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 10:4",
+							"text": "Do not run faster or labor more than you have strength and means provided to enable you to translate; but be diligent unto the end.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 10:5",
+							"text": "Pray always, that you may come off conqueror; yea, that you may conquer Satan, and that you may escape the hands of the servants of Satan that do uphold his work.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 10:6",
+							"text": "Behold, they have sought to destroy you; yea, even the man in whom you have trusted has sought to destroy you.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 10:7",
+							"text": "And for this cause I said that he is a wicked man, for he has sought to take away the things wherewith you have been entrusted; and he has also sought to destroy your gift.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 10:8",
+							"text": "And because you have delivered the writings into his hands, behold, wicked men have taken them from you.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 10:9",
+							"text": "Therefore, you have delivered them up, yea, that which was sacred, unto wickedness.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 10:10",
+							"text": "And, behold, Satan hath put it into their hearts to alter the words which you have caused to be written, or which you have translated, which have gone out of your hands.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 10:11",
+							"text": "And behold, I say unto you, that because they have altered the words, they read contrary from that which you translated and caused to be written;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 10:12",
+							"text": "And, on this wise, the devil has sought to lay a cunning plan, that he may destroy this work;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 10:13",
+							"text": "For he hath put into their hearts to do this, that by lying they may say they have caught you in the words which you have pretended to translate.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 10:14",
+							"text": "Verily, I say unto you, that I will not suffer that Satan shall accomplish his evil design in this thing.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 10:15",
+							"text": "For behold, he has put it into their hearts to get thee to tempt the Lord thy God, in asking to translate it over again.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 10:16",
+							"text": "And then, behold, they say and think in their hearts\u2014We will see if God has given him power to translate; if so, he will also give him power again;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 10:17",
+							"text": "And if God giveth him power again, or if he translates again, or, in other words, if he bringeth forth the same words, behold, we have the same with us, and we have altered them;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 10:18",
+							"text": "Therefore they will not agree, and we will say that he has lied in his words, and that he has no gift, and that he has no power;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 10:19",
+							"text": "Therefore we will destroy him, and also the work; and we will do this that we may not be ashamed in the end, and that we may get glory of the world.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 10:20",
+							"text": "Verily, verily, I say unto you, that Satan has great hold upon their hearts; he stirreth them up to iniquity against that which is good;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 10:21",
+							"text": "And their hearts are corrupt, and full of wickedness and abominations; and they love darkness rather than light, because their deeds are evil; therefore they will not ask of me.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 10:22",
+							"text": "Satan stirreth them up, that he may lead their souls to destruction.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 10:23",
+							"text": "And thus he has laid a cunning plan, thinking to destroy the work of God; but I will require this at their hands, and it shall turn to their shame and condemnation in the day of judgment.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 10:24",
+							"text": "Yea, he stirreth up their hearts to anger against this work.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 10:25",
+							"text": "Yea, he saith unto them: Deceive and lie in wait to catch, that ye may destroy; behold, this is no harm. And thus he flattereth them, and telleth them that it is no sin to lie that they may catch a man in a lie, that they may destroy him.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 10:26",
+							"text": "And thus he flattereth them, and leadeth them along until he draggeth their souls down to hell; and thus he causeth them to catch themselves in their own snare.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 10:27",
+							"text": "And thus he goeth up and down, to and fro in the earth, seeking to destroy the souls of men.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 10:28",
+							"text": "Verily, verily, I say unto you, wo be unto him that lieth to deceive because he supposeth that another lieth to deceive, for such are not exempt from the justice of God.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 10:29",
+							"text": "Now, behold, they have altered these words, because Satan saith unto them: He hath deceived you\u2014and thus he flattereth them away to do iniquity, to get thee to tempt the Lord thy God.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 10:30",
+							"text": "Behold, I say unto you, that you shall not translate again those words which have gone forth out of your hands;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 10:31",
+							"text": "For, behold, they shall not accomplish their evil designs in lying against those words. For, behold, if you should bring forth the same words they will say that you have lied and that you have pretended to translate, but that you have contradicted yourself.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 10:32",
+							"text": "And, behold, they will publish this, and Satan will harden the hearts of the people to stir them up to anger against you, that they will not believe my words.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 10:33",
+							"text": "Thus Satan thinketh to overpower your testimony in this generation, that the work may not come forth in this generation.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 10:34",
+							"text": "But behold, here is wisdom, and because I show unto you wisdom, and give you commandments concerning these things, what you shall do, show it not unto the world until you have accomplished the work of translation.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 10:35",
+							"text": "Marvel not that I said unto you: Here is wisdom, show it not unto the world\u2014for I said, show it not unto the world, that you may be preserved.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 10:36",
+							"text": "Behold, I do not say that you shall not show it unto the righteous;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 10:37",
+							"text": "But as you cannot always judge the righteous, or as you cannot always tell the wicked from the righteous, therefore I say unto you, hold your peace until I shall see fit to make all things known unto the world concerning the matter.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 10:38",
+							"text": "And now, verily I say unto you, that an account of those things that you have written, which have gone out of your hands, is engraven upon the plates of Nephi;",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 10:39",
+							"text": "Yea, and you remember it was said in those writings that a more particular account was given of these things upon the plates of Nephi.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 10:40",
+							"text": "And now, because the account which is engraven upon the plates of Nephi is more particular concerning the things which, in my wisdom, I would bring to the knowledge of the people in this account\u2014",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 10:41",
+							"text": "Therefore, you shall translate the engravings which are on the plates of Nephi, down even till you come to the reign of king Benjamin, or until you come to that which you have translated, which you have retained;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 10:42",
+							"text": "And behold, you shall publish it as the record of Nephi; and thus I will confound those who have altered my words.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 10:43",
+							"text": "I will not suffer that they shall destroy my work; yea, I will show unto them that my wisdom is greater than the cunning of the devil.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 10:44",
+							"text": "Behold, they have only got a part, or an abridgment of the account of Nephi.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 10:45",
+							"text": "Behold, there are many things engraven upon the plates of Nephi which do throw greater views upon my gospel; therefore, it is wisdom in me that you should translate this first part of the engravings of Nephi, and send forth in this work.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 10:46",
+							"text": "And, behold, all the remainder of this work does contain all those parts of my gospel which my holy prophets, yea, and also my disciples, desired in their prayers should come forth unto this people.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 10:47",
+							"text": "And I said unto them, that it should be granted unto them according to their faith in their prayers;",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 10:48",
+							"text": "Yea, and this was their faith\u2014that my gospel, which I gave unto them that they might preach in their days, might come unto their brethren the Lamanites, and also all that had become Lamanites because of their dissensions.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 10:49",
+							"text": "Now, this is not all\u2014their faith in their prayers was that this gospel should be made known also, if it were possible that other nations should possess this land;",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 10:50",
+							"text": "And thus they did leave a blessing upon this land in their prayers, that whosoever should believe in this gospel in this land might have eternal life;",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 10:51",
+							"text": "Yea, that it might be free unto all of whatsoever nation, kindred, tongue, or people they may be.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 10:52",
+							"text": "And now, behold, according to their faith in their prayers will I bring this part of my gospel to the knowledge of my people. Behold, I do not bring it to destroy that which they have received, but to build it up.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 10:53",
+							"text": "And for this cause have I said: If this generation harden not their hearts, I will establish my church among them.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 10:54",
+							"text": "Now I do not say this to destroy my church, but I say this to build up my church;",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 10:55",
+							"text": "Therefore, whosoever belongeth to my church need not fear, for such shall inherit the kingdom of heaven.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 10:56",
+							"text": "But it is they who do not fear me, neither keep my commandments but build up churches unto themselves to get gain, yea, and all those that do wickedly and build up the kingdom of the devil\u2014yea, verily, verily, I say unto you, that it is they that I will disturb, and cause to tremble and shake to the center.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 10:57",
+							"text": "Behold, I am Jesus Christ, the Son of God. I came unto mine own, and mine own received me not.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 10:58",
+							"text": "I am the light which shineth in darkness, and the darkness comprehendeth it not.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 10:59",
+							"text": "I am he who said\u2014Other sheep have I which are not of this fold\u2014unto my disciples, and many there were that understood me not.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 10:60",
+							"text": "And I will show unto this people that I had other sheep, and that they were a branch of the house of Jacob;",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 10:61",
+							"text": "And I will bring to light their marvelous works, which they did in my name;",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 10:62",
+							"text": "Yea, and I will also bring to light my gospel which was ministered unto them, and, behold, they shall not deny that which you have received, but they shall build it up, and shall bring to light the true points of my doctrine, yea, and the only doctrine which is in me.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 10:63",
+							"text": "And this I do that I may establish my gospel, that there may not be so much contention; yea, Satan doth stir up the hearts of the people to contention concerning the points of my doctrine; and in these things they do err, for they do wrest the scriptures and do not understand them.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 10:64",
+							"text": "Therefore, I will unfold unto them this great mystery;",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 10:65",
+							"text": "For, behold, I will gather them as a hen gathereth her chickens under her wings, if they will not harden their hearts;",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 10:66",
+							"text": "Yea, if they will come, they may, and partake of the waters of life freely.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 10:67",
+							"text": "Behold, this is my doctrine\u2014whosoever repenteth and cometh unto me, the same is my church.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 10:68",
+							"text": "Whosoever declareth more or less than this, the same is not of me, but is against me; therefore he is not of my church.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 10:69",
+							"text": "And now, behold, whosoever is of my church, and endureth of my church to the end, him will I establish upon my rock, and the gates of hell shall not prevail against them.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 10:70",
+							"text": "And now, remember the words of him who is the life and light of the world, your Redeemer, your Lord and your God. Amen.",
+							"verse": 70
+						}
+					]
+				},
+				{
+					"chapter": 11,
+					"reference": "D&C 11",
+					"verses": [{
+							"reference": "D&C 11:1",
+							"text": "A great and marvelous work is about to come forth among the children of men.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 11:2",
+							"text": "Behold, I am God; give heed to my word, which is quick and powerful, sharper than a two-edged sword, to the dividing asunder of both joints and marrow; therefore give heed unto my word.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 11:3",
+							"text": "Behold, the field is white already to harvest; therefore, whoso desireth to reap let him thrust in his sickle with his might, and reap while the day lasts, that he may treasure up for his soul everlasting salvation in the kingdom of God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 11:4",
+							"text": "Yea, whosoever will thrust in his sickle and reap, the same is called of God.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 11:5",
+							"text": "Therefore, if you will ask of me you shall receive; if you will knock it shall be opened unto you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 11:6",
+							"text": "Now, as you have asked, behold, I say unto you, keep my commandments, and seek to bring forth and establish the cause of Zion.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 11:7",
+							"text": "Seek not for riches but for wisdom; and, behold, the mysteries of God shall be unfolded unto you, and then shall you be made rich. Behold, he that hath eternal life is rich.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 11:8",
+							"text": "Verily, verily, I say unto you, even as you desire of me so it shall be done unto you; and, if you desire, you shall be the means of doing much good in this generation.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 11:9",
+							"text": "Say nothing but repentance unto this generation. Keep my commandments, and assist to bring forth my work, according to my commandments, and you shall be blessed.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 11:10",
+							"text": "Behold, thou hast a gift, or thou shalt have a gift if thou wilt desire of me in faith, with an honest heart, believing in the power of Jesus Christ, or in my power which speaketh unto thee;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 11:11",
+							"text": "For, behold, it is I that speak; behold, I am the light which shineth in darkness, and by my power I give these words unto thee.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 11:12",
+							"text": "And now, verily, verily, I say unto thee, put your trust in that Spirit which leadeth to do good\u2014yea, to do justly, to walk humbly, to judge righteously; and this is my Spirit.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 11:13",
+							"text": "Verily, verily, I say unto you, I will impart unto you of my Spirit, which shall enlighten your mind, which shall fill your soul with joy;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 11:14",
+							"text": "And then shall ye know, or by this shall you know, all things whatsoever you desire of me, which are pertaining unto things of righteousness, in faith believing in me that you shall receive.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 11:15",
+							"text": "Behold, I command you that you need not suppose that you are called to preach until you are called.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 11:16",
+							"text": "Wait a little longer, until you shall have my word, my rock, my church, and my gospel, that you may know of a surety my doctrine.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 11:17",
+							"text": "And then, behold, according to your desires, yea, even according to your faith shall it be done unto you.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 11:18",
+							"text": "Keep my commandments; hold your peace; appeal unto my Spirit;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 11:19",
+							"text": "Yea, cleave unto me with all your heart, that you may assist in bringing to light those things of which has been spoken\u2014yea, the translation of my work; be patient until you shall accomplish it.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 11:20",
+							"text": "Behold, this is your work, to keep my commandments, yea, with all your might, mind and strength.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 11:21",
+							"text": "Seek not to declare my word, but first seek to obtain my word, and then shall your tongue be loosed; then, if you desire, you shall have my Spirit and my word, yea, the power of God unto the convincing of men.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 11:22",
+							"text": "But now hold your peace; study my word which hath gone forth among the children of men, and also study my word which shall come forth among the children of men, or that which is now translating, yea, until you have obtained all which I shall grant unto the children of men in this generation, and then shall all things be added thereto.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 11:23",
+							"text": "Behold thou art Hyrum, my son; seek the kingdom of God, and all things shall be added according to that which is just.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 11:24",
+							"text": "Build upon my rock, which is my gospel;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 11:25",
+							"text": "Deny not the spirit of revelation, nor the spirit of prophecy, for wo unto him that denieth these things;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 11:26",
+							"text": "Therefore, treasure up in your heart until the time which is in my wisdom that you shall go forth.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 11:27",
+							"text": "Behold, I speak unto all who have good desires, and have thrust in their sickle to reap.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 11:28",
+							"text": "Behold, I am Jesus Christ, the Son of God. I am the life and the light of the world.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 11:29",
+							"text": "I am the same who came unto mine own and mine own received me not;",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 11:30",
+							"text": "But verily, verily, I say unto you, that as many as receive me, to them will I give power to become the sons of God, even to them that believe on my name. Amen.",
+							"verse": 30
+						}
+					]
+				},
+				{
+					"chapter": 12,
+					"reference": "D&C 12",
+					"verses": [{
+							"reference": "D&C 12:1",
+							"text": "A great and marvelous work is about to come forth among the children of men.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 12:2",
+							"text": "Behold, I am God; give heed to my word, which is quick and powerful, sharper than a two-edged sword, to the dividing asunder of both joints and marrow; therefore, give heed unto my word.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 12:3",
+							"text": "Behold, the field is white already to harvest; therefore, whoso desireth to reap let him thrust in his sickle with his might, and reap while the day lasts, that he may treasure up for his soul everlasting salvation in the kingdom of God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 12:4",
+							"text": "Yea, whosoever will thrust in his sickle and reap, the same is called of God.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 12:5",
+							"text": "Therefore, if you will ask of me you shall receive; if you will knock it shall be opened unto you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 12:6",
+							"text": "Now, as you have asked, behold, I say unto you, keep my commandments, and seek to bring forth and establish the cause of Zion.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 12:7",
+							"text": "Behold, I speak unto you, and also to all those who have desires to bring forth and establish this work;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 12:8",
+							"text": "And no one can assist in this work except he shall be humble and full of love, having faith, hope, and charity, being temperate in all things, whatsoever shall be entrusted to his care.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 12:9",
+							"text": "Behold, I am the light and the life of the world, that speak these words, therefore give heed with your might, and then you are called. Amen.",
+							"verse": 9
+						}
+					]
+				},
+				{
+					"chapter": 13,
+					"reference": "D&C 13",
+					"verses": [{
+						"reference": "D&C 13:1",
+						"text": "Upon you my fellow servants, in the name of Messiah I confer the Priesthood of Aaron, which holds the keys of the ministering of angels, and of the gospel of repentance, and of baptism by immersion for the remission of sins; and this shall never be taken again from the earth, until the sons of Levi do offer again an offering unto the Lord in righteousness.",
+						"verse": 1
+					}]
+				},
+				{
+					"chapter": 14,
+					"reference": "D&C 14",
+					"verses": [{
+							"reference": "D&C 14:1",
+							"text": "A great and marvelous work is about to come forth unto the children of men.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 14:2",
+							"text": "Behold, I am God; give heed to my word, which is quick and powerful, sharper than a two-edged sword, to the dividing asunder of both joints and marrow; therefore give heed unto my word.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 14:3",
+							"text": "Behold, the field is white already to harvest; therefore, whoso desireth to reap let him thrust in his sickle with his might, and reap while the day lasts, that he may treasure up for his soul everlasting salvation in the kingdom of God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 14:4",
+							"text": "Yea, whosoever will thrust in his sickle and reap, the same is called of God.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 14:5",
+							"text": "Therefore, if you will ask of me you shall receive; if you will knock it shall be opened unto you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 14:6",
+							"text": "Seek to bring forth and establish my Zion. Keep my commandments in all things.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 14:7",
+							"text": "And, if you keep my commandments and endure to the end you shall have eternal life, which gift is the greatest of all the gifts of God.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 14:8",
+							"text": "And it shall come to pass, that if you shall ask the Father in my name, in faith believing, you shall receive the Holy Ghost, which giveth utterance, that you may stand as a witness of the things of which you shall both hear and see, and also that you may declare repentance unto this generation.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 14:9",
+							"text": "Behold, I am Jesus Christ, the Son of the living God, who created the heavens and the earth, a light which cannot be hid in darkness;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 14:10",
+							"text": "Wherefore, I must bring forth the fulness of my gospel from the Gentiles unto the house of Israel.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 14:11",
+							"text": "And behold, thou art David, and thou art called to assist; which thing if ye do, and are faithful, ye shall be blessed both spiritually and temporally, and great shall be your reward. Amen.",
+							"verse": 11
+						}
+					]
+				},
+				{
+					"chapter": 15,
+					"reference": "D&C 15",
+					"verses": [{
+							"reference": "D&C 15:1",
+							"text": "Hearken, my servant John, and listen to the words of Jesus Christ, your Lord and your Redeemer.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 15:2",
+							"text": "For behold, I speak unto you with sharpness and with power, for mine arm is over all the earth.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 15:3",
+							"text": "And I will tell you that which no man knoweth save me and thee alone\u2014",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 15:4",
+							"text": "For many times you have desired of me to know that which would be of the most worth unto you.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 15:5",
+							"text": "Behold, blessed are you for this thing, and for speaking my words which I have given you according to my commandments.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 15:6",
+							"text": "And now, behold, I say unto you, that the thing which will be of the most worth unto you will be to declare repentance unto this people, that you may bring souls unto me, that you may rest with them in the kingdom of my Father. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 16,
+					"reference": "D&C 16",
+					"verses": [{
+							"reference": "D&C 16:1",
+							"text": "Hearken, my servant Peter, and listen to the words of Jesus Christ, your Lord and your Redeemer.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 16:2",
+							"text": "For behold, I speak unto you with sharpness and with power, for mine arm is over all the earth.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 16:3",
+							"text": "And I will tell you that which no man knoweth save me and thee alone\u2014",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 16:4",
+							"text": "For many times you have desired of me to know that which would be of the most worth unto you.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 16:5",
+							"text": "Behold, blessed are you for this thing, and for speaking my words which I have given unto you according to my commandments.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 16:6",
+							"text": "And now, behold, I say unto you, that the thing which will be of the most worth unto you will be to declare repentance unto this people, that you may bring souls unto me, that you may rest with them in the kingdom of my Father. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 17,
+					"reference": "D&C 17",
+					"verses": [{
+							"reference": "D&C 17:1",
+							"text": "Behold, I say unto you, that you must rely upon my word, which if you do with full purpose of heart, you shall have a view of the plates, and also of the breastplate, the sword of Laban, the Urim and Thummim, which were given to the brother of Jared upon the mount, when he talked with the Lord face to face, and the miraculous directors which were given to Lehi while in the wilderness, on the borders of the Red Sea.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 17:2",
+							"text": "And it is by your faith that you shall obtain a view of them, even by that faith which was had by the prophets of old.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 17:3",
+							"text": "And after that you have obtained faith, and have seen them with your eyes, you shall testify of them, by the power of God;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 17:4",
+							"text": "And this you shall do that my servant Joseph Smith, Jun., may not be destroyed, that I may bring about my righteous purposes unto the children of men in this work.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 17:5",
+							"text": "And ye shall testify that you have seen them, even as my servant Joseph Smith, Jun., has seen them; for it is by my power that he has seen them, and it is because he had faith.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 17:6",
+							"text": "And he has translated the book, even that part which I have commanded him, and as your Lord and your God liveth it is true.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 17:7",
+							"text": "Wherefore, you have received the same power, and the same faith, and the same gift like unto him;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 17:8",
+							"text": "And if you do these last commandments of mine, which I have given you, the gates of hell shall not prevail against you; for my grace is sufficient for you, and you shall be lifted up at the last day.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 17:9",
+							"text": "And I, Jesus Christ, your Lord and your God, have spoken it unto you, that I might bring about my righteous purposes unto the children of men. Amen.",
+							"verse": 9
+						}
+					]
+				},
+				{
+					"chapter": 18,
+					"reference": "D&C 18",
+					"verses": [{
+							"reference": "D&C 18:1",
+							"text": "Now, behold, because of the thing which you, my servant Oliver Cowdery, have desired to know of me, I give unto you these words:",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 18:2",
+							"text": "Behold, I have manifested unto you, by my Spirit in many instances, that the things which you have written are true; wherefore you know that they are true.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 18:3",
+							"text": "And if you know that they are true, behold, I give unto you a commandment, that you rely upon the things which are written;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 18:4",
+							"text": "For in them are all things written concerning the foundation of my church, my gospel, and my rock.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 18:5",
+							"text": "Wherefore, if you shall build up my church, upon the foundation of my gospel and my rock, the gates of hell shall not prevail against you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 18:6",
+							"text": "Behold, the world is ripening in iniquity; and it must needs be that the children of men are stirred up unto repentance, both the Gentiles and also the house of Israel.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 18:7",
+							"text": "Wherefore, as thou hast been baptized by the hands of my servant Joseph Smith, Jun., according to that which I have commanded him, he hath fulfilled the thing which I commanded him.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 18:8",
+							"text": "And now, marvel not that I have called him unto mine own purpose, which purpose is known in me; wherefore, if he shall be diligent in keeping my commandments he shall be blessed unto eternal life; and his name is Joseph.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 18:9",
+							"text": "And now, Oliver Cowdery, I speak unto you, and also unto David Whitmer, by the way of commandment; for, behold, I command all men everywhere to repent, and I speak unto you, even as unto Paul mine apostle, for you are called even with that same calling with which he was called.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 18:10",
+							"text": "Remember the worth of souls is great in the sight of God;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 18:11",
+							"text": "For, behold, the Lord your Redeemer suffered death in the flesh; wherefore he suffered the pain of all men, that all men might repent and come unto him.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 18:12",
+							"text": "And he hath risen again from the dead, that he might bring all men unto him, on conditions of repentance.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 18:13",
+							"text": "And how great is his joy in the soul that repenteth!",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 18:14",
+							"text": "Wherefore, you are called to cry repentance unto this people.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 18:15",
+							"text": "And if it so be that you should labor all your days in crying repentance unto this people, and bring, save it be one soul unto me, how great shall be your joy with him in the kingdom of my Father!",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 18:16",
+							"text": "And now, if your joy will be great with one soul that you have brought unto me into the kingdom of my Father, how great will be your joy if you should bring many souls unto me!",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 18:17",
+							"text": "Behold, you have my gospel before you, and my rock, and my salvation.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 18:18",
+							"text": "Ask the Father in my name in faith, believing that you shall receive, and you shall have the Holy Ghost, which manifesteth all things which are expedient unto the children of men.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 18:19",
+							"text": "And if you have not faith, hope, and charity, you can do nothing.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 18:20",
+							"text": "Contend against no church, save it be the church of the devil.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 18:21",
+							"text": "Take upon you the name of Christ, and speak the truth in soberness.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 18:22",
+							"text": "And as many as repent and are baptized in my name, which is Jesus Christ, and endure to the end, the same shall be saved.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 18:23",
+							"text": "Behold, Jesus Christ is the name which is given of the Father, and there is none other name given whereby man can be saved;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 18:24",
+							"text": "Wherefore, all men must take upon them the name which is given of the Father, for in that name shall they be called at the last day;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 18:25",
+							"text": "Wherefore, if they know not the name by which they are called, they cannot have place in the kingdom of my Father.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 18:26",
+							"text": "And now, behold, there are others who are called to declare my gospel, both unto Gentile and unto Jew;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 18:27",
+							"text": "Yea, even twelve; and the Twelve shall be my disciples, and they shall take upon them my name; and the Twelve are they who shall desire to take upon them my name with full purpose of heart.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 18:28",
+							"text": "And if they desire to take upon them my name with full purpose of heart, they are called to go into all the world to preach my gospel unto every creature.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 18:29",
+							"text": "And they are they who are ordained of me to baptize in my name, according to that which is written;",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 18:30",
+							"text": "And you have that which is written before you; wherefore, you must perform it according to the words which are written.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 18:31",
+							"text": "And now I speak unto you, the Twelve\u2014Behold, my grace is sufficient for you; you must walk uprightly before me and sin not.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 18:32",
+							"text": "And, behold, you are they who are ordained of me to ordain priests and teachers; to declare my gospel, according to the power of the Holy Ghost which is in you, and according to the callings and gifts of God unto men;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 18:33",
+							"text": "And I, Jesus Christ, your Lord and your God, have spoken it.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 18:34",
+							"text": "These words are not of men nor of man, but of me; wherefore, you shall testify they are of me and not of man;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 18:35",
+							"text": "For it is my voice which speaketh them unto you; for they are given by my Spirit unto you, and by my power you can read them one to another; and save it were by my power you could not have them;",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 18:36",
+							"text": "Wherefore, you can testify that you have heard my voice, and know my words.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 18:37",
+							"text": "And now, behold, I give unto you, Oliver Cowdery, and also unto David Whitmer, that you shall search out the Twelve, who shall have the desires of which I have spoken;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 18:38",
+							"text": "And by their desires and their works you shall know them.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 18:39",
+							"text": "And when you have found them you shall show these things unto them.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 18:40",
+							"text": "And you shall fall down and worship the Father in my name.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 18:41",
+							"text": "And you must preach unto the world, saying: You must repent and be baptized, in the name of Jesus Christ;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 18:42",
+							"text": "For all men must repent and be baptized, and not only men, but women, and children who have arrived at the years of accountability.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 18:43",
+							"text": "And now, after that you have received this, you must keep my commandments in all things;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 18:44",
+							"text": "And by your hands I will work a marvelous work among the children of men, unto the convincing of many of their sins, that they may come unto repentance, and that they may come unto the kingdom of my Father.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 18:45",
+							"text": "Wherefore, the blessings which I give unto you are above all things.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 18:46",
+							"text": "And after that you have received this, if you keep not my commandments you cannot be saved in the kingdom of my Father.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 18:47",
+							"text": "Behold, I, Jesus Christ, your Lord and your God, and your Redeemer, by the power of my Spirit have spoken it. Amen.",
+							"verse": 47
+						}
+					]
+				},
+				{
+					"chapter": 19,
+					"reference": "D&C 19",
+					"verses": [{
+							"reference": "D&C 19:1",
+							"text": "I am Alpha and Omega, Christ the Lord; yea, even I am he, the beginning and the end, the Redeemer of the world.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 19:2",
+							"text": "I, having accomplished and finished the will of him whose I am, even the Father, concerning me\u2014having done this that I might subdue all things unto myself\u2014",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 19:3",
+							"text": "Retaining all power, even to the destroying of Satan and his works at the end of the world, and the last great day of judgment, which I shall pass upon the inhabitants thereof, judging every man according to his works and the deeds which he hath done.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 19:4",
+							"text": "And surely every man must repent or suffer, for I, God, am endless.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 19:5",
+							"text": "Wherefore, I revoke not the judgments which I shall pass, but woes shall go forth, weeping, wailing and gnashing of teeth, yea, to those who are found on my left hand.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 19:6",
+							"text": "Nevertheless, it is not written that there shall be no end to this torment, but it is written endless torment.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 19:7",
+							"text": "Again, it is written eternal damnation; wherefore it is more express than other scriptures, that it might work upon the hearts of the children of men, altogether for my name's glory.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 19:8",
+							"text": "Wherefore, I will explain unto you this mystery, for it is meet unto you to know even as mine apostles.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 19:9",
+							"text": "I speak unto you that are chosen in this thing, even as one, that you may enter into my rest.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 19:10",
+							"text": "For, behold, the mystery of godliness, how great is it! For, behold, I am endless, and the punishment which is given from my hand is endless punishment, for Endless is my name. Wherefore\u2014",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 19:11",
+							"text": "Eternal punishment is God's punishment.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 19:12",
+							"text": "Endless punishment is God's punishment.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 19:13",
+							"text": "Wherefore, I command you to repent, and keep the commandments which you have received by the hand of my servant Joseph Smith, Jun., in my name;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 19:14",
+							"text": "And it is by my almighty power that you have received them;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 19:15",
+							"text": "Therefore I command you to repent\u2014repent, lest I smite you by the rod of my mouth, and by my wrath, and by my anger, and your sufferings be sore\u2014how sore you know not, how exquisite you know not, yea, how hard to bear you know not.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 19:16",
+							"text": "For behold, I, God, have suffered these things for all, that they might not suffer if they would repent;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 19:17",
+							"text": "But if they would not repent they must suffer even as I;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 19:18",
+							"text": "Which suffering caused myself, even God, the greatest of all, to tremble because of pain, and to bleed at every pore, and to suffer both body and spirit\u2014and would that I might not drink the bitter cup, and shrink\u2014",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 19:19",
+							"text": "Nevertheless, glory be to the Father, and I partook and finished my preparations unto the children of men.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 19:20",
+							"text": "Wherefore, I command you again to repent, lest I humble you with my almighty power; and that you confess your sins, lest you suffer these punishments of which I have spoken, of which in the smallest, yea, even in the least degree you have tasted at the time I withdrew my Spirit.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 19:21",
+							"text": "And I command you that you preach naught but repentance, and show not these things unto the world until it is wisdom in me.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 19:22",
+							"text": "For they cannot bear meat now, but milk they must receive; wherefore, they must not know these things, lest they perish.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 19:23",
+							"text": "Learn of me, and listen to my words; walk in the meekness of my Spirit, and you shall have peace in me.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 19:24",
+							"text": "I am Jesus Christ; I came by the will of the Father, and I do his will.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 19:25",
+							"text": "And again, I command thee that thou shalt not covet thy neighbor's wife; nor seek thy neighbor's life.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 19:26",
+							"text": "And again, I command thee that thou shalt not covet thine own property, but impart it freely to the printing of the Book of Mormon, which contains the truth and the word of God\u2014",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 19:27",
+							"text": "Which is my word to the Gentile, that soon it may go to the Jew, of whom the Lamanites are a remnant, that they may believe the gospel, and look not for a Messiah to come who has already come.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 19:28",
+							"text": "And again, I command thee that thou shalt pray vocally as well as in thy heart; yea, before the world as well as in secret, in public as well as in private.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 19:29",
+							"text": "And thou shalt declare glad tidings, yea, publish it upon the mountains, and upon every high place, and among every people that thou shalt be permitted to see.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 19:30",
+							"text": "And thou shalt do it with all humility, trusting in me, reviling not against revilers.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 19:31",
+							"text": "And of tenets thou shalt not talk, but thou shalt declare repentance and faith on the Savior, and remission of sins by baptism, and by fire, yea, even the Holy Ghost.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 19:32",
+							"text": "Behold, this is a great and the last commandment which I shall give unto you concerning this matter; for this shall suffice for thy daily walk, even unto the end of thy life.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 19:33",
+							"text": "And misery thou shalt receive if thou wilt slight these counsels, yea, even the destruction of thyself and property.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 19:34",
+							"text": "Impart a portion of thy property, yea, even part of thy lands, and all save the support of thy family.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 19:35",
+							"text": "Pay the debt thou hast contracted with the printer. Release thyself from bondage.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 19:36",
+							"text": "Leave thy house and home, except when thou shalt desire to see thy family;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 19:37",
+							"text": "And speak freely to all; yea, preach, exhort, declare the truth, even with a loud voice, with a sound of rejoicing, crying\u2014Hosanna, hosanna, blessed be the name of the Lord God!",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 19:38",
+							"text": "Pray always, and I will pour out my Spirit upon you, and great shall be your blessing\u2014yea, even more than if you should obtain treasures of earth and corruptibleness to the extent thereof.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 19:39",
+							"text": "Behold, canst thou read this without rejoicing and lifting up thy heart for gladness?",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 19:40",
+							"text": "Or canst thou run about longer as a blind guide?",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 19:41",
+							"text": "Or canst thou be humble and meek, and conduct thyself wisely before me? Yea, come unto me thy Savior. Amen.",
+							"verse": 41
+						}
+					]
+				},
+				{
+					"chapter": 20,
+					"reference": "D&C 20",
+					"verses": [{
+							"reference": "D&C 20:1",
+							"text": "The rise of the Church of Christ in these last days, being one thousand eight hundred and thirty years since the coming of our Lord and Savior Jesus Christ in the flesh, it being regularly organized and established agreeable to the laws of our country, by the will and commandments of God, in the fourth month, and on the sixth day of the month which is called April\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 20:2",
+							"text": "Which commandments were given to Joseph Smith, Jun., who was called of God, and ordained an apostle of Jesus Christ, to be the first elder of this church;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 20:3",
+							"text": "And to Oliver Cowdery, who was also called of God, an apostle of Jesus Christ, to be the second elder of this church, and ordained under his hand;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 20:4",
+							"text": "And this according to the grace of our Lord and Savior Jesus Christ, to whom be all glory, both now and forever. Amen.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 20:5",
+							"text": "After it was truly manifested unto this first elder that he had received a remission of his sins, he was entangled again in the vanities of the world;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 20:6",
+							"text": "But after repenting, and humbling himself sincerely, through faith, God ministered unto him by an holy angel, whose countenance was as lightning, and whose garments were pure and white above all other whiteness;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 20:7",
+							"text": "And gave unto him commandments which inspired him;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 20:8",
+							"text": "And gave him power from on high, by the means which were before prepared, to translate the Book of Mormon;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 20:9",
+							"text": "Which contains a record of a fallen people, and the fulness of the gospel of Jesus Christ to the Gentiles and to the Jews also;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 20:10",
+							"text": "Which was given by inspiration, and is confirmed to others by the ministering of angels, and is declared unto the world by them\u2014",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 20:11",
+							"text": "Proving to the world that the holy scriptures are true, and that God does inspire men and call them to his holy work in this age and generation, as well as in generations of old;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 20:12",
+							"text": "Thereby showing that he is the same God yesterday, today, and forever. Amen.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 20:13",
+							"text": "Therefore, having so great witnesses, by them shall the world be judged, even as many as shall hereafter come to a knowledge of this work.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 20:14",
+							"text": "And those who receive it in faith, and work righteousness, shall receive a crown of eternal life;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 20:15",
+							"text": "But those who harden their hearts in unbelief, and reject it, it shall turn to their own condemnation\u2014",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 20:16",
+							"text": "For the Lord God has spoken it; and we, the elders of the church, have heard and bear witness to the words of the glorious Majesty on high, to whom be glory forever and ever. Amen.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 20:17",
+							"text": "By these things we know that there is a God in heaven, who is infinite and eternal, from everlasting to everlasting the same unchangeable God, the framer of heaven and earth, and all things which are in them;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 20:18",
+							"text": "And that he created man, male and female, after his own image and in his own likeness, created he them;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 20:19",
+							"text": "And gave unto them commandments that they should love and serve him, the only living and true God, and that he should be the only being whom they should worship.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 20:20",
+							"text": "But by the transgression of these holy laws man became sensual and devilish, and became fallen man.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 20:21",
+							"text": "Wherefore, the Almighty God gave his Only Begotten Son, as it is written in those scriptures which have been given of him.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 20:22",
+							"text": "He suffered temptations but gave no heed unto them.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 20:23",
+							"text": "He was crucified, died, and rose again the third day;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 20:24",
+							"text": "And ascended into heaven, to sit down on the right hand of the Father, to reign with almighty power according to the will of the Father;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 20:25",
+							"text": "That as many as would believe and be baptized in his holy name, and endure in faith to the end, should be saved\u2014",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 20:26",
+							"text": "Not only those who believed after he came in the meridian of time, in the flesh, but all those from the beginning, even as many as were before he came, who believed in the words of the holy prophets, who spake as they were inspired by the gift of the Holy Ghost, who truly testified of him in all things, should have eternal life,",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 20:27",
+							"text": "As well as those who should come after, who should believe in the gifts and callings of God by the Holy Ghost, which beareth record of the Father and of the Son;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 20:28",
+							"text": "Which Father, Son, and Holy Ghost are one God, infinite and eternal, without end. Amen.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 20:29",
+							"text": "And we know that all men must repent and believe on the name of Jesus Christ, and worship the Father in his name, and endure in faith on his name to the end, or they cannot be saved in the kingdom of God.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 20:30",
+							"text": "And we know that justification through the grace of our Lord and Savior Jesus Christ is just and true;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 20:31",
+							"text": "And we know also, that sanctification through the grace of our Lord and Savior Jesus Christ is just and true, to all those who love and serve God with all their mights, minds, and strength.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 20:32",
+							"text": "But there is a possibility that man may fall from grace and depart from the living God;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 20:33",
+							"text": "Therefore let the church take heed and pray always, lest they fall into temptation;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 20:34",
+							"text": "Yea, and even let those who are sanctified take heed also.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 20:35",
+							"text": "And we know that these things are true and according to the revelations of John, neither adding to, nor diminishing from the prophecy of his book, the holy scriptures, or the revelations of God which shall come hereafter by the gift and power of the Holy Ghost, the voice of God, or the ministering of angels.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 20:36",
+							"text": "And the Lord God has spoken it; and honor, power and glory be rendered to his holy name, both now and ever. Amen.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 20:37",
+							"text": "And again, by way of commandment to the church concerning the manner of baptism\u2014All those who humble themselves before God, and desire to be baptized, and come forth with broken hearts and contrite spirits, and witness before the church that they have truly repented of all their sins, and are willing to take upon them the name of Jesus Christ, having a determination to serve him to the end, and truly manifest by their works that they have received of the Spirit of Christ unto the remission of their sins, shall be received by baptism into his church.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 20:38",
+							"text": "The duty of the elders, priests, teachers, deacons, and members of the church of Christ\u2014An apostle is an elder, and it is his calling to baptize;",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 20:39",
+							"text": "And to ordain other elders, priests, teachers, and deacons;",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 20:40",
+							"text": "And to administer bread and wine\u2014the emblems of the flesh and blood of Christ\u2014",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 20:41",
+							"text": "And to confirm those who are baptized into the church, by the laying on of hands for the baptism of fire and the Holy Ghost, according to the scriptures;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 20:42",
+							"text": "And to teach, expound, exhort, baptize, and watch over the church;",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 20:43",
+							"text": "And to confirm the church by the laying on of the hands, and the giving of the Holy Ghost;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 20:44",
+							"text": "And to take the lead of all meetings.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 20:45",
+							"text": "The elders are to conduct the meetings as they are led by the Holy Ghost, according to the commandments and revelations of God.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 20:46",
+							"text": "The priest's duty is to preach, teach, expound, exhort, and baptize, and administer the sacrament,",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 20:47",
+							"text": "And visit the house of each member, and exhort them to pray vocally and in secret and attend to all family duties.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 20:48",
+							"text": "And he may also ordain other priests, teachers, and deacons.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 20:49",
+							"text": "And he is to take the lead of meetings when there is no elder present;",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 20:50",
+							"text": "But when there is an elder present, he is only to preach, teach, expound, exhort, and baptize,",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 20:51",
+							"text": "And visit the house of each member, exhorting them to pray vocally and in secret and attend to all family duties.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 20:52",
+							"text": "In all these duties the priest is to assist the elder if occasion requires.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 20:53",
+							"text": "The teacher's duty is to watch over the church always, and be with and strengthen them;",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 20:54",
+							"text": "And see that there is no iniquity in the church, neither hardness with each other, neither lying, backbiting, nor evil speaking;",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 20:55",
+							"text": "And see that the church meet together often, and also see that all the members do their duty.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 20:56",
+							"text": "And he is to take the lead of meetings in the absence of the elder or priest\u2014",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 20:57",
+							"text": "And is to be assisted always, in all his duties in the church, by the deacons, if occasion requires.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 20:58",
+							"text": "But neither teachers nor deacons have authority to baptize, administer the sacrament, or lay on hands;",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 20:59",
+							"text": "They are, however, to warn, expound, exhort, and teach, and invite all to come unto Christ.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 20:60",
+							"text": "Every elder, priest, teacher, or deacon is to be ordained according to the gifts and callings of God unto him; and he is to be ordained by the power of the Holy Ghost, which is in the one who ordains him.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 20:61",
+							"text": "The several elders composing this church of Christ are to meet in conference once in three months, or from time to time as said conferences shall direct or appoint;",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 20:62",
+							"text": "And said conferences are to do whatever church business is necessary to be done at the time.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 20:63",
+							"text": "The elders are to receive their licenses from other elders, by vote of the church to which they belong, or from the conferences.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 20:64",
+							"text": "Each priest, teacher, or deacon, who is ordained by a priest, may take a certificate from him at the time, which certificate, when presented to an elder, shall entitle him to a license, which shall authorize him to perform the duties of his calling, or he may receive it from a conference.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 20:65",
+							"text": "No person is to be ordained to any office in this church, where there is a regularly organized branch of the same, without the vote of that church;",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 20:66",
+							"text": "But the presiding elders, traveling bishops, high councilors, high priests, and elders, may have the privilege of ordaining, where there is no branch of the church that a vote may be called.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 20:67",
+							"text": "Every president of the high priesthood (or presiding elder), bishop, high councilor, and high priest, is to be ordained by the direction of a high council or general conference.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 20:68",
+							"text": "The duty of the members after they are received by baptism\u2014The elders or priests are to have a sufficient time to expound all things concerning the church of Christ to their understanding, previous to their partaking of the sacrament and being confirmed by the laying on of the hands of the elders, so that all things may be done in order.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 20:69",
+							"text": "And the members shall manifest before the church, and also before the elders, by a godly walk and conversation, that they are worthy of it, that there may be works and faith agreeable to the holy scriptures\u2014walking in holiness before the Lord.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 20:70",
+							"text": "Every member of the church of Christ having children is to bring them unto the elders before the church, who are to lay their hands upon them in the name of Jesus Christ, and bless them in his name.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 20:71",
+							"text": "No one can be received into the church of Christ unless he has arrived unto the years of accountability before God, and is capable of repentance.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 20:72",
+							"text": "Baptism is to be administered in the following manner unto all those who repent\u2014",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 20:73",
+							"text": "The person who is called of God and has authority from Jesus Christ to baptize, shall go down into the water with the person who has presented himself or herself for baptism, and shall say, calling him or her by name: Having been commissioned of Jesus Christ, I baptize you in the name of the Father, and of the Son, and of the Holy Ghost. Amen.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 20:74",
+							"text": "Then shall he immerse him or her in the water, and come forth again out of the water.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 20:75",
+							"text": "It is expedient that the church meet together often to partake of bread and wine in the remembrance of the Lord Jesus;",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 20:76",
+							"text": "And the elder or priest shall administer it; and after this manner shall he administer it\u2014he shall kneel with the church and call upon the Father in solemn prayer, saying:",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 20:77",
+							"text": "O God, the Eternal Father, we ask thee in the name of thy Son, Jesus Christ, to bless and sanctify this bread to the souls of all those who partake of it, that they may eat in remembrance of the body of thy Son, and witness unto thee, O God, the Eternal Father, that they are willing to take upon them the name of thy Son, and always remember him and keep his commandments which he has given them; that they may always have his Spirit to be with them. Amen.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 20:78",
+							"text": "The manner of administering the wine\u2014he shall take the cup also, and say:",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 20:79",
+							"text": "O God, the Eternal Father, we ask thee in the name of thy Son, Jesus Christ, to bless and sanctify this wine to the souls of all those who drink of it, that they may do it in remembrance of the blood of thy Son, which was shed for them; that they may witness unto thee, O God, the Eternal Father, that they do always remember him, that they may have his Spirit to be with them. Amen.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 20:80",
+							"text": "Any member of the church of Christ transgressing, or being overtaken in a fault, shall be dealt with as the scriptures direct.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 20:81",
+							"text": "It shall be the duty of the several churches, composing the church of Christ, to send one or more of their teachers to attend the several conferences held by the elders of the church,",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 20:82",
+							"text": "With a list of the names of the several members uniting themselves with the church since the last conference; or send by the hand of some priest; so that a regular list of all the names of the whole church may be kept in a book by one of the elders, whomsoever the other elders shall appoint from time to time;",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 20:83",
+							"text": "And also, if any have been expelled from the church, so that their names may be blotted out of the general church record of names.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 20:84",
+							"text": "All members removing from the church where they reside, if going to a church where they are not known, may take a letter certifying that they are regular members and in good standing, which certificate may be signed by any elder or priest if the member receiving the letter is personally acquainted with the elder or priest, or it may be signed by the teachers or deacons of the church.",
+							"verse": 84
+						}
+					]
+				},
+				{
+					"chapter": 21,
+					"reference": "D&C 21",
+					"verses": [{
+							"reference": "D&C 21:1",
+							"text": "Behold, there shall be a record kept among you; and in it thou shalt be called a seer, a translator, a prophet, an apostle of Jesus Christ, an elder of the church through the will of God the Father, and the grace of your Lord Jesus Christ,",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 21:2",
+							"text": "Being inspired of the Holy Ghost to lay the foundation thereof, and to build it up unto the most holy faith.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 21:3",
+							"text": "Which church was organized and established in the year of your Lord eighteen hundred and thirty, in the fourth month, and on the sixth day of the month which is called April.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 21:4",
+							"text": "Wherefore, meaning the church, thou shalt give heed unto all his words and commandments which he shall give unto you as he receiveth them, walking in all holiness before me;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 21:5",
+							"text": "For his word ye shall receive, as if from mine own mouth, in all patience and faith.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 21:6",
+							"text": "For by doing these things the gates of hell shall not prevail against you; yea, and the Lord God will disperse the powers of darkness from before you, and cause the heavens to shake for your good, and his name's glory.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 21:7",
+							"text": "For thus saith the Lord God: Him have I inspired to move the cause of Zion in mighty power for good, and his diligence I know, and his prayers I have heard.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 21:8",
+							"text": "Yea, his weeping for Zion I have seen, and I will cause that he shall mourn for her no longer; for his days of rejoicing are come unto the remission of his sins, and the manifestations of my blessings upon his works.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 21:9",
+							"text": "For, behold, I will bless all those who labor in my vineyard with a mighty blessing, and they shall believe on his words, which are given him through me by the Comforter, which manifesteth that Jesus was crucified by sinful men for the sins of the world, yea, for the remission of sins unto the contrite heart.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 21:10",
+							"text": "Wherefore it behooveth me that he should be ordained by you, Oliver Cowdery mine apostle;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 21:11",
+							"text": "This being an ordinance unto you, that you are an elder under his hand, he being the first unto you, that you might be an elder unto this church of Christ, bearing my name\u2014",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 21:12",
+							"text": "And the first preacher of this church unto the church, and before the world, yea, before the Gentiles; yea, and thus saith the Lord God, lo, lo! to the Jews also. Amen.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 22,
+					"reference": "D&C 22",
+					"verses": [{
+							"reference": "D&C 22:1",
+							"text": "Behold, I say unto you that all old covenants have I caused to be done away in this thing; and this is a new and an everlasting covenant, even that which was from the beginning.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 22:2",
+							"text": "Wherefore, although a man should be baptized an hundred times it availeth him nothing, for you cannot enter in at the strait gate by the law of Moses, neither by your dead works.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 22:3",
+							"text": "For it is because of your dead works that I have caused this last covenant and this church to be built up unto me, even as in days of old.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 22:4",
+							"text": "Wherefore, enter ye in at the gate, as I have commanded, and seek not to counsel your God. Amen.",
+							"verse": 4
+						}
+					]
+				},
+				{
+					"chapter": 23,
+					"reference": "D&C 23",
+					"verses": [{
+							"reference": "D&C 23:1",
+							"text": "Behold, I speak unto you, Oliver, a few words. Behold, thou art blessed, and art under no condemnation. But beware of pride, lest thou shouldst enter into temptation.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 23:2",
+							"text": "Make known thy calling unto the church, and also before the world, and thy heart shall be opened to preach the truth from henceforth and forever. Amen.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 23:3",
+							"text": "Behold, I speak unto you, Hyrum, a few words; for thou also art under no condemnation, and thy heart is opened, and thy tongue loosed; and thy calling is to exhortation, and to strengthen the church continually. Wherefore thy duty is unto the church forever, and this because of thy family. Amen.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 23:4",
+							"text": "Behold, I speak a few words unto you, Samuel; for thou also art under no condemnation, and thy calling is to exhortation, and to strengthen the church; and thou art not as yet called to preach before the world. Amen.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 23:5",
+							"text": "Behold, I speak a few words unto you, Joseph; for thou also art under no condemnation, and thy calling also is to exhortation, and to strengthen the church; and this is thy duty from henceforth and forever. Amen.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 23:6",
+							"text": "Behold, I manifest unto you, Joseph Knight, by these words, that you must take up your cross, in the which you must pray vocally before the world as well as in secret, and in your family, and among your friends, and in all places.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 23:7",
+							"text": "And, behold, it is your duty to unite with the true church, and give your language to exhortation continually, that you may receive the reward of the laborer. Amen.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 24,
+					"reference": "D&C 24",
+					"verses": [{
+							"reference": "D&C 24:1",
+							"text": "Behold, thou wast called and chosen to write the Book of Mormon, and to my ministry; and I have lifted thee up out of thine afflictions, and have counseled thee, that thou hast been delivered from all thine enemies, and thou hast been delivered from the powers of Satan and from darkness!",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 24:2",
+							"text": "Nevertheless, thou art not excusable in thy transgressions; nevertheless, go thy way and sin no more.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 24:3",
+							"text": "Magnify thine office; and after thou hast sowed thy fields and secured them, go speedily unto the church which is in Colesville, Fayette, and Manchester, and they shall support thee; and I will bless them both spiritually and temporally;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 24:4",
+							"text": "But if they receive thee not, I will send upon them a cursing instead of a blessing.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 24:5",
+							"text": "And thou shalt continue in calling upon God in my name, and writing the things which shall be given thee by the Comforter, and expounding all scriptures unto the church.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 24:6",
+							"text": "And it shall be given thee in the very moment what thou shalt speak and write, and they shall hear it, or I will send unto them a cursing instead of a blessing.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 24:7",
+							"text": "For thou shalt devote all thy service in Zion; and in this thou shalt have strength.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 24:8",
+							"text": "Be patient in afflictions, for thou shalt have many; but endure them, for, lo, I am with thee, even unto the end of thy days.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 24:9",
+							"text": "And in temporal labors thou shalt not have strength, for this is not thy calling. Attend to thy calling and thou shalt have wherewith to magnify thine office, and to expound all scriptures, and continue in laying on of the hands and confirming the churches.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 24:10",
+							"text": "And thy brother Oliver shall continue in bearing my name before the world, and also to the church. And he shall not suppose that he can say enough in my cause; and lo, I am with him to the end.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 24:11",
+							"text": "In me he shall have glory, and not of himself, whether in weakness or in strength, whether in bonds or free;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 24:12",
+							"text": "And at all times, and in all places, he shall open his mouth and declare my gospel as with the voice of a trump, both day and night. And I will give unto him strength such as is not known among men.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 24:13",
+							"text": "Require not miracles, except I shall command you, except casting out devils, healing the sick, and against poisonous serpents, and against deadly poisons;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 24:14",
+							"text": "And these things ye shall not do, except it be required of you by them who desire it, that the scriptures might be fulfilled; for ye shall do according to that which is written.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 24:15",
+							"text": "And in whatsoever place ye shall enter, and they receive you not in my name, ye shall leave a cursing instead of a blessing, by casting off the dust of your feet against them as a testimony, and cleansing your feet by the wayside.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 24:16",
+							"text": "And it shall come to pass that whosoever shall lay their hands upon you by violence, ye shall command to be smitten in my name; and, behold, I will smite them according to your words, in mine own due time.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 24:17",
+							"text": "And whosoever shall go to law with thee shall be cursed by the law.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 24:18",
+							"text": "And thou shalt take no purse nor scrip, neither staves, neither two coats, for the church shall give unto thee in the very hour what thou needest for food and for raiment, and for shoes and for money, and for scrip.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 24:19",
+							"text": "For thou art called to prune my vineyard with a mighty pruning, yea, even for the last time; yea, and also all those whom thou hast ordained, and they shall do even according to this pattern. Amen.",
+							"verse": 19
+						}
+					]
+				},
+				{
+					"chapter": 25,
+					"reference": "D&C 25",
+					"verses": [{
+							"reference": "D&C 25:1",
+							"text": "Hearken unto the voice of the Lord your God, while I speak unto you, Emma Smith, my daughter; for verily I say unto you, all those who receive my gospel are sons and daughters in my kingdom.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 25:2",
+							"text": "A revelation I give unto you concerning my will; and if thou art faithful and walk in the paths of virtue before me, I will preserve thy life, and thou shalt receive an inheritance in Zion.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 25:3",
+							"text": "Behold, thy sins are forgiven thee, and thou art an elect lady, whom I have called.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 25:4",
+							"text": "Murmur not because of the things which thou hast not seen, for they are withheld from thee and from the world, which is wisdom in me in a time to come.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 25:5",
+							"text": "And the office of thy calling shall be for a comfort unto my servant, Joseph Smith, Jun., thy husband, in his afflictions, with consoling words, in the spirit of meekness.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 25:6",
+							"text": "And thou shalt go with him at the time of his going, and be unto him for a scribe, while there is no one to be a scribe for him, that I may send my servant, Oliver Cowdery, whithersoever I will.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 25:7",
+							"text": "And thou shalt be ordained under his hand to expound scriptures, and to exhort the church, according as it shall be given thee by my Spirit.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 25:8",
+							"text": "For he shall lay his hands upon thee, and thou shalt receive the Holy Ghost, and thy time shall be given to writing, and to learning much.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 25:9",
+							"text": "And thou needest not fear, for thy husband shall support thee in the church; for unto them is his calling, that all things might be revealed unto them, whatsoever I will, according to their faith.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 25:10",
+							"text": "And verily I say unto thee that thou shalt lay aside the things of this world, and seek for the things of a better.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 25:11",
+							"text": "And it shall be given thee, also, to make a selection of sacred hymns, as it shall be given thee, which is pleasing unto me, to be had in my church.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 25:12",
+							"text": "For my soul delighteth in the song of the heart; yea, the song of the righteous is a prayer unto me, and it shall be answered with a blessing upon their heads.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 25:13",
+							"text": "Wherefore, lift up thy heart and rejoice, and cleave unto the covenants which thou hast made.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 25:14",
+							"text": "Continue in the spirit of meekness, and beware of pride. Let thy soul delight in thy husband, and the glory which shall come upon him.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 25:15",
+							"text": "Keep my commandments continually, and a crown of righteousness thou shalt receive. And except thou do this, where I am you cannot come.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 25:16",
+							"text": "And verily, verily, I say unto you, that this is my voice unto all. Amen.",
+							"verse": 16
+						}
+					]
+				}
+			]
+		},
+		{
+			"book": "D&C 26-50",
+			"chapters": [{
+					"chapter": 26,
+					"reference": "D&C 26",
+					"verses": [{
+							"reference": "D&C 26:1",
+							"text": "Behold, I say unto you that you shall let your time be devoted to the studying of the scriptures, and to preaching, and to confirming the church at Colesville, and to performing your labors on the land, such as is required, until after you shall go to the west to hold the next conference; and then it shall be made known what you shall do.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 26:2",
+							"text": "And all things shall be done by common consent in the church, by much prayer and faith, for all things you shall receive by faith. Amen.",
+							"verse": 2
+						}
+					]
+				},
+				{
+					"chapter": 27,
+					"reference": "D&C 27",
+					"verses": [{
+							"reference": "D&C 27:1",
+							"text": "Listen to the voice of Jesus Christ, your Lord, your God, and your Redeemer, whose word is quick and powerful.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 27:2",
+							"text": "For, behold, I say unto you, that it mattereth not what ye shall eat or what ye shall drink when ye partake of the sacrament, if it so be that ye do it with an eye single to my glory\u2014remembering unto the Father my body which was laid down for you, and my blood which was shed for the remission of your sins.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 27:3",
+							"text": "Wherefore, a commandment I give unto you, that you shall not purchase wine neither strong drink of your enemies;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 27:4",
+							"text": "Wherefore, you shall partake of none except it is made new among you; yea, in this my Father's kingdom which shall be built up on the earth.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 27:5",
+							"text": "Behold, this is wisdom in me; wherefore, marvel not, for the hour cometh that I will drink of the fruit of the vine with you on the earth, and with Moroni, whom I have sent unto you to reveal the Book of Mormon, containing the fulness of my everlasting gospel, to whom I have committed the keys of the record of the stick of Ephraim;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 27:6",
+							"text": "And also with Elias, to whom I have committed the keys of bringing to pass the restoration of all things spoken by the mouth of all the holy prophets since the world began, concerning the last days;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 27:7",
+							"text": "And also John the son of Zacharias, which Zacharias he (Elias) visited and gave promise that he should have a son, and his name should be John, and he should be filled with the spirit of Elias;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 27:8",
+							"text": "Which John I have sent unto you, my servants, Joseph Smith, Jun., and Oliver Cowdery, to ordain you unto the first priesthood which you have received, that you might be called and ordained even as Aaron;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 27:9",
+							"text": "And also Elijah, unto whom I have committed the keys of the power of turning the hearts of the fathers to the children, and the hearts of the children to the fathers, that the whole earth may not be smitten with a curse;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 27:10",
+							"text": "And also with Joseph and Jacob, and Isaac, and Abraham, your fathers, by whom the promises remain;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 27:11",
+							"text": "And also with Michael, or Adam, the father of all, the prince of all, the ancient of days;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 27:12",
+							"text": "And also with Peter, and James, and John, whom I have sent unto you, by whom I have ordained you and confirmed you to be apostles, and especial witnesses of my name, and bear the keys of your ministry and of the same things which I revealed unto them;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 27:13",
+							"text": "Unto whom I have committed the keys of my kingdom, and a dispensation of the gospel for the last times; and for the fulness of times, in the which I will gather together in one all things, both which are in heaven, and which are on earth;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 27:14",
+							"text": "And also with all those whom my Father hath given me out of the world.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 27:15",
+							"text": "Wherefore, lift up your hearts and rejoice, and gird up your loins, and take upon you my whole armor, that ye may be able to withstand the evil day, having done all, that ye may be able to stand.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 27:16",
+							"text": "Stand, therefore, having your loins girt about with truth, having on the breastplate of righteousness, and your feet shod with the preparation of the gospel of peace, which I have sent mine angels to commit unto you;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 27:17",
+							"text": "Taking the shield of faith wherewith ye shall be able to quench all the fiery darts of the wicked;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 27:18",
+							"text": "And take the helmet of salvation, and the sword of my Spirit, which I will pour out upon you, and my word which I reveal unto you, and be agreed as touching all things whatsoever ye ask of me, and be faithful until I come, and ye shall be caught up, that where I am ye shall be also. Amen.",
+							"verse": 18
+						}
+					]
+				},
+				{
+					"chapter": 28,
+					"reference": "D&C 28",
+					"verses": [{
+							"reference": "D&C 28:1",
+							"text": "Behold, I say unto thee, Oliver, that it shall be given unto thee that thou shalt be heard by the church in all things whatsoever thou shalt teach them by the Comforter, concerning the revelations and commandments which I have given.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 28:2",
+							"text": "But, behold, verily, verily, I say unto thee, no one shall be appointed to receive commandments and revelations in this church excepting my servant Joseph Smith, Jun., for he receiveth them even as Moses.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 28:3",
+							"text": "And thou shalt be obedient unto the things which I shall give unto him, even as Aaron, to declare faithfully the commandments and the revelations, with power and authority unto the church.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 28:4",
+							"text": "And if thou art led at any time by the Comforter to speak or teach, or at all times by the way of commandment unto the church, thou mayest do it.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 28:5",
+							"text": "But thou shalt not write by way of commandment, but by wisdom;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 28:6",
+							"text": "And thou shalt not command him who is at thy head, and at the head of the church;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 28:7",
+							"text": "For I have given him the keys of the mysteries, and the revelations which are sealed, until I shall appoint unto them another in his stead.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 28:8",
+							"text": "And now, behold, I say unto you that you shall go unto the Lamanites and preach my gospel unto them; and inasmuch as they receive thy teachings thou shalt cause my church to be established among them; and thou shalt have revelations, but write them not by way of commandment.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 28:9",
+							"text": "And now, behold, I say unto you that it is not revealed, and no man knoweth where the city Zion shall be built, but it shall be given hereafter. Behold, I say unto you that it shall be on the borders by the Lamanites.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 28:10",
+							"text": "Thou shalt not leave this place until after the conference; and my servant Joseph shall be appointed to preside over the conference by the voice of it, and what he saith to thee thou shalt tell.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 28:11",
+							"text": "And again, thou shalt take thy brother, Hiram Page, between him and thee alone, and tell him that those things which he hath written from that stone are not of me and that Satan deceiveth him;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 28:12",
+							"text": "For, behold, these things have not been appointed unto him, neither shall anything be appointed unto any of this church contrary to the church covenants.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 28:13",
+							"text": "For all things must be done in order, and by common consent in the church, by the prayer of faith.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 28:14",
+							"text": "And thou shalt assist to settle all these things, according to the covenants of the church, before thou shalt take thy journey among the Lamanites.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 28:15",
+							"text": "And it shall be given thee from the time thou shalt go, until the time thou shalt return, what thou shalt do.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 28:16",
+							"text": "And thou must open thy mouth at all times, declaring my gospel with the sound of rejoicing. Amen.",
+							"verse": 16
+						}
+					]
+				},
+				{
+					"chapter": 29,
+					"reference": "D&C 29",
+					"verses": [{
+							"reference": "D&C 29:1",
+							"text": "Listen to the voice of Jesus Christ, your Redeemer, the Great I AM, whose arm of mercy hath atoned for your sins;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 29:2",
+							"text": "Who will gather his people even as a hen gathereth her chickens under her wings, even as many as will hearken to my voice and humble themselves before me, and call upon me in mighty prayer.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 29:3",
+							"text": "Behold, verily, verily, I say unto you, that at this time your sins are forgiven you, therefore ye receive these things; but remember to sin no more, lest perils shall come upon you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 29:4",
+							"text": "Verily, I say unto you that ye are chosen out of the world to declare my gospel with the sound of rejoicing, as with the voice of a trump.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 29:5",
+							"text": "Lift up your hearts and be glad, for I am in your midst, and am your advocate with the Father; and it is his good will to give you the kingdom.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 29:6",
+							"text": "And, as it is written\u2014Whatsoever ye shall ask in faith, being united in prayer according to my command, ye shall receive.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 29:7",
+							"text": "And ye are called to bring to pass the gathering of mine elect; for mine elect hear my voice and harden not their hearts;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 29:8",
+							"text": "Wherefore the decree hath gone forth from the Father that they shall be gathered in unto one place upon the face of this land, to prepare their hearts and be prepared in all things against the day when tribulation and desolation are sent forth upon the wicked.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 29:9",
+							"text": "For the hour is nigh and the day soon at hand when the earth is ripe; and all the proud and they that do wickedly shall be as stubble; and I will burn them up, saith the Lord of Hosts, that wickedness shall not be upon the earth;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 29:10",
+							"text": "For the hour is nigh, and that which was spoken by mine apostles must be fulfilled; for as they spoke so shall it come to pass;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 29:11",
+							"text": "For I will reveal myself from heaven with power and great glory, with all the hosts thereof, and dwell in righteousness with men on earth a thousand years, and the wicked shall not stand.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 29:12",
+							"text": "And again, verily, verily, I say unto you, and it hath gone forth in a firm decree, by the will of the Father, that mine apostles, the Twelve which were with me in my ministry at Jerusalem, shall stand at my right hand at the day of my coming in a pillar of fire, being clothed with robes of righteousness, with crowns upon their heads, in glory even as I am, to judge the whole house of Israel, even as many as have loved me and kept my commandments, and none else.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 29:13",
+							"text": "For a trump shall sound both long and loud, even as upon Mount Sinai, and all the earth shall quake, and they shall come forth\u2014yea, even the dead which died in me, to receive a crown of righteousness, and to be clothed upon, even as I am, to be with me, that we may be one.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 29:14",
+							"text": "But, behold, I say unto you that before this great day shall come the sun shall be darkened, and the moon shall be turned into blood, and the stars shall fall from heaven, and there shall be greater signs in heaven above and in the earth beneath;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 29:15",
+							"text": "And there shall be weeping and wailing among the hosts of men;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 29:16",
+							"text": "And there shall be a great hailstorm sent forth to destroy the crops of the earth.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 29:17",
+							"text": "And it shall come to pass, because of the wickedness of the world, that I will take vengeance upon the wicked, for they will not repent; for the cup of mine indignation is full; for behold, my blood shall not cleanse them if they hear me not.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 29:18",
+							"text": "Wherefore, I the Lord God will send forth flies upon the face of the earth, which shall take hold of the inhabitants thereof, and shall eat their flesh, and shall cause maggots to come in upon them;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 29:19",
+							"text": "And their tongues shall be stayed that they shall not utter against me; and their flesh shall fall from off their bones, and their eyes from their sockets;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 29:20",
+							"text": "And it shall come to pass that the beasts of the forest and the fowls of the air shall devour them up.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 29:21",
+							"text": "And the great and abominable church, which is the whore of all the earth, shall be cast down by devouring fire, according as it is spoken by the mouth of Ezekiel the prophet, who spoke of these things, which have not come to pass but surely must, as I live, for abominations shall not reign.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 29:22",
+							"text": "And again, verily, verily, I say unto you that when the thousand years are ended, and men again begin to deny their God, then will I spare the earth but for a little season;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 29:23",
+							"text": "And the end shall come, and the heaven and the earth shall be consumed and pass away, and there shall be a new heaven and a new earth.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 29:24",
+							"text": "For all old things shall pass away, and all things shall become new, even the heaven and the earth, and all the fulness thereof, both men and beasts, the fowls of the air, and the fishes of the sea;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 29:25",
+							"text": "And not one hair, neither mote, shall be lost, for it is the workmanship of mine hand.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 29:26",
+							"text": "But, behold, verily I say unto you, before the earth shall pass away, Michael, mine archangel, shall sound his trump, and then shall all the dead awake, for their graves shall be opened, and they shall come forth\u2014yea, even all.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 29:27",
+							"text": "And the righteous shall be gathered on my right hand unto eternal life; and the wicked on my left hand will I be ashamed to own before the Father;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 29:28",
+							"text": "Wherefore I will say unto them\u2014Depart from me, ye cursed, into everlasting fire, prepared for the devil and his angels.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 29:29",
+							"text": "And now, behold, I say unto you, never at any time have I declared from mine own mouth that they should return, for where I am they cannot come, for they have no power.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 29:30",
+							"text": "But remember that all my judgments are not given unto men; and as the words have gone forth out of my mouth even so shall they be fulfilled, that the first shall be last, and that the last shall be first in all things whatsoever I have created by the word of my power, which is the power of my Spirit.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 29:31",
+							"text": "For by the power of my Spirit created I them; yea, all things both spiritual and temporal\u2014",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 29:32",
+							"text": "First spiritual, secondly temporal, which is the beginning of my work; and again, first temporal, and secondly spiritual, which is the last of my work\u2014",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 29:33",
+							"text": "Speaking unto you that you may naturally understand; but unto myself my works have no end, neither beginning; but it is given unto you that ye may understand, because ye have asked it of me and are agreed.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 29:34",
+							"text": "Wherefore, verily I say unto you that all things unto me are spiritual, and not at any time have I given unto you a law which was temporal; neither any man, nor the children of men; neither Adam, your father, whom I created.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 29:35",
+							"text": "Behold, I gave unto him that he should be an agent unto himself; and I gave unto him commandment, but no temporal commandment gave I unto him, for my commandments are spiritual; they are not natural nor temporal, neither carnal nor sensual.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 29:36",
+							"text": "And it came to pass that Adam, being tempted of the devil\u2014for, behold, the devil was before Adam, for he rebelled against me, saying, Give me thine honor, which is my power; and also a third part of the hosts of heaven turned he away from me because of their agency;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 29:37",
+							"text": "And they were thrust down, and thus came the devil and his angels;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 29:38",
+							"text": "And, behold, there is a place prepared for them from the beginning, which place is hell.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 29:39",
+							"text": "And it must needs be that the devil should tempt the children of men, or they could not be agents unto themselves; for if they never should have bitter they could not know the sweet\u2014",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 29:40",
+							"text": "Wherefore, it came to pass that the devil tempted Adam, and he partook of the forbidden fruit and transgressed the commandment, wherein he became subject to the will of the devil, because he yielded unto temptation.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 29:41",
+							"text": "Wherefore, I, the Lord God, caused that he should be cast out from the Garden of Eden, from my presence, because of his transgression, wherein he became spiritually dead, which is the first death, even that same death which is the last death, which is spiritual, which shall be pronounced upon the wicked when I shall say: Depart, ye cursed.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 29:42",
+							"text": "But, behold, I say unto you that I, the Lord God, gave unto Adam and unto his seed, that they should not die as to the temporal death, until I, the Lord God, should send forth angels to declare unto them repentance and redemption, through faith on the name of mine Only Begotten Son.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 29:43",
+							"text": "And thus did I, the Lord God, appoint unto man the days of his probation\u2014that by his natural death he might be raised in immortality unto eternal life, even as many as would believe;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 29:44",
+							"text": "And they that believe not unto eternal damnation; for they cannot be redeemed from their spiritual fall, because they repent not;",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 29:45",
+							"text": "For they love darkness rather than light, and their deeds are evil, and they receive their wages of whom they list to obey.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 29:46",
+							"text": "But behold, I say unto you, that little children are redeemed from the foundation of the world through mine Only Begotten;",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 29:47",
+							"text": "Wherefore, they cannot sin, for power is not given unto Satan to tempt little children, until they begin to become accountable before me;",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 29:48",
+							"text": "For it is given unto them even as I will, according to mine own pleasure, that great things may be required at the hand of their fathers.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 29:49",
+							"text": "And, again, I say unto you, that whoso having knowledge, have I not commanded to repent?",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 29:50",
+							"text": "And he that hath no understanding, it remaineth in me to do according as it is written. And now I declare no more unto you at this time. Amen.",
+							"verse": 50
+						}
+					]
+				},
+				{
+					"chapter": 30,
+					"reference": "D&C 30",
+					"verses": [{
+							"reference": "D&C 30:1",
+							"text": "Behold, I say unto you, David, that you have feared man and have not relied on me for strength as you ought.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 30:2",
+							"text": "But your mind has been on the things of the earth more than on the things of me, your Maker, and the ministry whereunto you have been called; and you have not given heed unto my Spirit, and to those who were set over you, but have been persuaded by those whom I have not commanded.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 30:3",
+							"text": "Wherefore, you are left to inquire for yourself at my hand, and ponder upon the things which you have received.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 30:4",
+							"text": "And your home shall be at your father's house, until I give unto you further commandments. And you shall attend to the ministry in the church, and before the world, and in the regions round about. Amen.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 30:5",
+							"text": "Behold, I say unto you, Peter, that you shall take your journey with your brother Oliver; for the time has come that it is expedient in me that you shall open your mouth to declare my gospel; therefore, fear not, but give heed unto the words and advice of your brother, which he shall give you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 30:6",
+							"text": "And be you afflicted in all his afflictions, ever lifting up your heart unto me in prayer and faith, for his and your deliverance; for I have given unto him power to build up my church among the Lamanites;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 30:7",
+							"text": "And none have I appointed to be his counselor over him in the church, concerning church matters, except it is his brother, Joseph Smith, Jun.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 30:8",
+							"text": "Wherefore, give heed unto these things and be diligent in keeping my commandments, and you shall be blessed unto eternal life. Amen.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 30:9",
+							"text": "Behold, I say unto you, my servant John, that thou shalt commence from this time forth to proclaim my gospel, as with the voice of a trump.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 30:10",
+							"text": "And your labor shall be at your brother Philip Burroughs', and in that region round about, yea, wherever you can be heard, until I command you to go from hence.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 30:11",
+							"text": "And your whole labor shall be in Zion, with all your soul, from henceforth; yea, you shall ever open your mouth in my cause, not fearing what man can do, for I am with you. Amen.",
+							"verse": 11
+						}
+					]
+				},
+				{
+					"chapter": 31,
+					"reference": "D&C 31",
+					"verses": [{
+							"reference": "D&C 31:1",
+							"text": "Thomas, my son, blessed are you because of your faith in my work.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 31:2",
+							"text": "Behold, you have had many afflictions because of your family; nevertheless, I will bless you and your family, yea, your little ones; and the day cometh that they will believe and know the truth and be one with you in my church.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 31:3",
+							"text": "Lift up your heart and rejoice, for the hour of your mission is come; and your tongue shall be loosed, and you shall declare glad tidings of great joy unto this generation.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 31:4",
+							"text": "You shall declare the things which have been revealed to my servant, Joseph Smith, Jun. You shall begin to preach from this time forth, yea, to reap in the field which is white already to be burned.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 31:5",
+							"text": "Therefore, thrust in your sickle with all your soul, and your sins are forgiven you, and you shall be laden with sheaves upon your back, for the laborer is worthy of his hire. Wherefore, your family shall live.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 31:6",
+							"text": "Behold, verily I say unto you, go from them only for a little time, and declare my word, and I will prepare a place for them.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 31:7",
+							"text": "Yea, I will open the hearts of the people, and they will receive you. And I will establish a church by your hand;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 31:8",
+							"text": "And you shall strengthen them and prepare them against the time when they shall be gathered.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 31:9",
+							"text": "Be patient in afflictions, revile not against those that revile. Govern your house in meekness, and be steadfast.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 31:10",
+							"text": "Behold, I say unto you that you shall be a physician unto the church, but not unto the world, for they will not receive you.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 31:11",
+							"text": "Go your way whithersoever I will, and it shall be given you by the Comforter what you shall do and whither you shall go.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 31:12",
+							"text": "Pray always, lest you enter into temptation and lose your reward.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 31:13",
+							"text": "Be faithful unto the end, and lo, I am with you. These words are not of man nor of men, but of me, even Jesus Christ, your Redeemer, by the will of the Father. Amen.",
+							"verse": 13
+						}
+					]
+				},
+				{
+					"chapter": 32,
+					"reference": "D&C 32",
+					"verses": [{
+							"reference": "D&C 32:1",
+							"text": "And now concerning my servant Parley P. Pratt, behold, I say unto him that as I live I will that he shall declare my gospel and learn of me, and be meek and lowly of heart.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 32:2",
+							"text": "And that which I have appointed unto him is that he shall go with my servants, Oliver Cowdery and Peter Whitmer, Jun., into the wilderness among the Lamanites.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 32:3",
+							"text": "And Ziba Peterson also shall go with them; and I myself will go with them and be in their midst; and I am their advocate with the Father, and nothing shall prevail against them.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 32:4",
+							"text": "And they shall give heed to that which is written, and pretend to no other revelation; and they shall pray always that I may unfold the same to their understanding.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 32:5",
+							"text": "And they shall give heed unto these words and trifle not, and I will bless them. Amen.",
+							"verse": 5
+						}
+					]
+				},
+				{
+					"chapter": 33,
+					"reference": "D&C 33",
+					"verses": [{
+							"reference": "D&C 33:1",
+							"text": "Behold, I say unto you, my servants Ezra and Northrop, open ye your ears and hearken to the voice of the Lord your God, whose word is quick and powerful, sharper than a two-edged sword, to the dividing asunder of the joints and marrow, soul and spirit; and is a discerner of the thoughts and intents of the heart.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 33:2",
+							"text": "For verily, verily, I say unto you that ye are called to lift up your voices as with the sound of a trump, to declare my gospel unto a crooked and perverse generation.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 33:3",
+							"text": "For behold, the field is white already to harvest; and it is the eleventh hour, and the last time that I shall call laborers into my vineyard.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 33:4",
+							"text": "And my vineyard has become corrupted every whit; and there is none which doeth good save it be a few; and they err in many instances because of priestcrafts, all having corrupt minds.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 33:5",
+							"text": "And verily, verily, I say unto you, that this church have I established and called forth out of the wilderness.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 33:6",
+							"text": "And even so will I gather mine elect from the four quarters of the earth, even as many as will believe in me, and hearken unto my voice.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 33:7",
+							"text": "Yea, verily, verily, I say unto you, that the field is white already to harvest; wherefore, thrust in your sickles, and reap with all your might, mind, and strength.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 33:8",
+							"text": "Open your mouths and they shall be filled, and you shall become even as Nephi of old, who journeyed from Jerusalem in the wilderness.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 33:9",
+							"text": "Yea, open your mouths and spare not, and you shall be laden with sheaves upon your backs, for lo, I am with you.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 33:10",
+							"text": "Yea, open your mouths and they shall be filled, saying: Repent, repent, and prepare ye the way of the Lord, and make his paths straight; for the kingdom of heaven is at hand;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 33:11",
+							"text": "Yea, repent and be baptized, every one of you, for a remission of your sins; yea, be baptized even by water, and then cometh the baptism of fire and of the Holy Ghost.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 33:12",
+							"text": "Behold, verily, verily, I say unto you, this is my gospel; and remember that they shall have faith in me or they can in nowise be saved;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 33:13",
+							"text": "And upon this rock I will build my church; yea, upon this rock ye are built, and if ye continue, the gates of hell shall not prevail against you.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 33:14",
+							"text": "And ye shall remember the church articles and covenants to keep them.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 33:15",
+							"text": "And whoso having faith you shall confirm in my church, by the laying on of the hands, and I will bestow the gift of the Holy Ghost upon them.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 33:16",
+							"text": "And the Book of Mormon and the holy scriptures are given of me for your instruction; and the power of my Spirit quickeneth all things.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 33:17",
+							"text": "Wherefore, be faithful, praying always, having your lamps trimmed and burning, and oil with you, that you may be ready at the coming of the Bridegroom\u2014",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 33:18",
+							"text": "For behold, verily, verily, I say unto you, that I come quickly. Even so. Amen.",
+							"verse": 18
+						}
+					]
+				},
+				{
+					"chapter": 34,
+					"reference": "D&C 34",
+					"verses": [{
+							"reference": "D&C 34:1",
+							"text": "My son Orson, hearken and hear and behold what I, the Lord God, shall say unto you, even Jesus Christ your Redeemer;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 34:2",
+							"text": "The light and the life of the world, a light which shineth in darkness and the darkness comprehendeth it not;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 34:3",
+							"text": "Who so loved the world that he gave his own life, that as many as would believe might become the sons of God. Wherefore you are my son;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 34:4",
+							"text": "And blessed are you because you have believed;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 34:5",
+							"text": "And more blessed are you because you are called of me to preach my gospel\u2014",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 34:6",
+							"text": "To lift up your voice as with the sound of a trump, both long and loud, and cry repentance unto a crooked and perverse generation, preparing the way of the Lord for his second coming.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 34:7",
+							"text": "For behold, verily, verily, I say unto you, the time is soon at hand that I shall come in a cloud with power and great glory.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 34:8",
+							"text": "And it shall be a great day at the time of my coming, for all nations shall tremble.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 34:9",
+							"text": "But before that great day shall come, the sun shall be darkened, and the moon be turned into blood; and the stars shall refuse their shining, and some shall fall, and great destructions await the wicked.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 34:10",
+							"text": "Wherefore, lift up your voice and spare not, for the Lord God hath spoken; therefore prophesy, and it shall be given by the power of the Holy Ghost.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 34:11",
+							"text": "And if you are faithful, behold, I am with you until I come\u2014",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 34:12",
+							"text": "And verily, verily, I say unto you, I come quickly. I am your Lord and your Redeemer. Even so. Amen.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 35,
+					"reference": "D&C 35",
+					"verses": [{
+							"reference": "D&C 35:1",
+							"text": "Listen to the voice of the Lord your God, even Alpha and Omega, the beginning and the end, whose course is one eternal round, the same today as yesterday, and forever.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 35:2",
+							"text": "I am Jesus Christ, the Son of God, who was crucified for the sins of the world, even as many as will believe on my name, that they may become the sons of God, even one in me as I am one in the Father, as the Father is one in me, that we may be one.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 35:3",
+							"text": "Behold, verily, verily, I say unto my servant Sidney, I have looked upon thee and thy works. I have heard thy prayers, and prepared thee for a greater work.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 35:4",
+							"text": "Thou art blessed, for thou shalt do great things. Behold thou wast sent forth, even as John, to prepare the way before me, and before Elijah which should come, and thou knewest it not.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 35:5",
+							"text": "Thou didst baptize by water unto repentance, but they received not the Holy Ghost;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 35:6",
+							"text": "But now I give unto thee a commandment, that thou shalt baptize by water, and they shall receive the Holy Ghost by the laying on of the hands, even as the apostles of old.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 35:7",
+							"text": "And it shall come to pass that there shall be a great work in the land, even among the Gentiles, for their folly and their abominations shall be made manifest in the eyes of all people.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 35:8",
+							"text": "For I am God, and mine arm is not shortened; and I will show miracles, signs, and wonders, unto all those who believe on my name.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 35:9",
+							"text": "And whoso shall ask it in my name in faith, they shall cast out devils; they shall heal the sick; they shall cause the blind to receive their sight, and the deaf to hear, and the dumb to speak, and the lame to walk.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 35:10",
+							"text": "And the time speedily cometh that great things are to be shown forth unto the children of men;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 35:11",
+							"text": "But without faith shall not anything be shown forth except desolations upon Babylon, the same which has made all nations drink of the wine of the wrath of her fornication.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 35:12",
+							"text": "And there are none that doeth good except those who are ready to receive the fulness of my gospel, which I have sent forth unto this generation.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 35:13",
+							"text": "Wherefore, I call upon the weak things of the world, those who are unlearned and despised, to thresh the nations by the power of my Spirit;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 35:14",
+							"text": "And their arm shall be my arm, and I will be their shield and their buckler; and I will gird up their loins, and they shall fight manfully for me; and their enemies shall be under their feet; and I will let fall the sword in their behalf, and by the fire of mine indignation will I preserve them.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 35:15",
+							"text": "And the poor and the meek shall have the gospel preached unto them, and they shall be looking forth for the time of my coming, for it is nigh at hand\u2014",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 35:16",
+							"text": "And they shall learn the parable of the fig tree, for even now already summer is nigh.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 35:17",
+							"text": "And I have sent forth the fulness of my gospel by the hand of my servant Joseph; and in weakness have I blessed him;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 35:18",
+							"text": "And I have given unto him the keys of the mystery of those things which have been sealed, even things which were from the foundation of the world, and the things which shall come from this time until the time of my coming, if he abide in me, and if not, another will I plant in his stead.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 35:19",
+							"text": "Wherefore, watch over him that his faith fail not, and it shall be given by the Comforter, the Holy Ghost, that knoweth all things.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 35:20",
+							"text": "And a commandment I give unto thee\u2014that thou shalt write for him; and the scriptures shall be given, even as they are in mine own bosom, to the salvation of mine own elect;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 35:21",
+							"text": "For they will hear my voice, and shall see me, and shall not be asleep, and shall abide the day of my coming; for they shall be purified, even as I am pure.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 35:22",
+							"text": "And now I say unto you, tarry with him, and he shall journey with you; forsake him not, and surely these things shall be fulfilled.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 35:23",
+							"text": "And inasmuch as ye do not write, behold, it shall be given unto him to prophesy; and thou shalt preach my gospel and call on the holy prophets to prove his words, as they shall be given him.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 35:24",
+							"text": "Keep all the commandments and covenants by which ye are bound; and I will cause the heavens to shake for your good, and Satan shall tremble and Zion shall rejoice upon the hills and flourish;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 35:25",
+							"text": "And Israel shall be saved in mine own due time; and by the keys which I have given shall they be led, and no more be confounded at all.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 35:26",
+							"text": "Lift up your hearts and be glad, your redemption draweth nigh.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 35:27",
+							"text": "Fear not, little flock, the kingdom is yours until I come. Behold, I come quickly. Even so. Amen.",
+							"verse": 27
+						}
+					]
+				},
+				{
+					"chapter": 36,
+					"reference": "D&C 36",
+					"verses": [{
+							"reference": "D&C 36:1",
+							"text": "Thus saith the Lord God, the Mighty One of Israel: Behold, I say unto you, my servant Edward, that you are blessed, and your sins are forgiven you, and you are called to preach my gospel as with the voice of a trump;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 36:2",
+							"text": "And I will lay my hand upon you by the hand of my servant Sidney Rigdon, and you shall receive my Spirit, the Holy Ghost, even the Comforter, which shall teach you the peaceable things of the kingdom;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 36:3",
+							"text": "And you shall declare it with a loud voice, saying: Hosanna, blessed be the name of the most high God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 36:4",
+							"text": "And now this calling and commandment give I unto you concerning all men\u2014",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 36:5",
+							"text": "That as many as shall come before my servants Sidney Rigdon and Joseph Smith, Jun., embracing this calling and commandment, shall be ordained and sent forth to preach the everlasting gospel among the nations\u2014",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 36:6",
+							"text": "Crying repentance, saying: Save yourselves from this untoward generation, and come forth out of the fire, hating even the garments spotted with the flesh.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 36:7",
+							"text": "And this commandment shall be given unto the elders of my church, that every man which will embrace it with singleness of heart may be ordained and sent forth, even as I have spoken.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 36:8",
+							"text": "I am Jesus Christ, the Son of God; wherefore, gird up your loins and I will suddenly come to my temple. Even so. Amen.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 37,
+					"reference": "D&C 37",
+					"verses": [{
+							"reference": "D&C 37:1",
+							"text": "Behold, I say unto you that it is not expedient in me that ye should translate any more until ye shall go to the Ohio, and this because of the enemy and for your sakes.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 37:2",
+							"text": "And again, I say unto you that ye shall not go until ye have preached my gospel in those parts, and have strengthened up the church whithersoever it is found, and more especially in Colesville; for, behold, they pray unto me in much faith.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 37:3",
+							"text": "And again, a commandment I give unto the church, that it is expedient in me that they should assemble together at the Ohio, against the time that my servant Oliver Cowdery shall return unto them.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 37:4",
+							"text": "Behold, here is wisdom, and let every man choose for himself until I come. Even so. Amen.",
+							"verse": 4
+						}
+					]
+				},
+				{
+					"chapter": 38,
+					"reference": "D&C 38",
+					"verses": [{
+							"reference": "D&C 38:1",
+							"text": "Thus saith the Lord your God, even Jesus Christ, the Great I AM, Alpha and Omega, the beginning and the end, the same which looked upon the wide expanse of eternity, and all the seraphic hosts of heaven, before the world was made;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 38:2",
+							"text": "The same which knoweth all things, for all things are present before mine eyes;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 38:3",
+							"text": "I am the same which spake, and the world was made, and all things came by me.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 38:4",
+							"text": "I am the same which have taken the Zion of Enoch into mine own bosom; and verily, I say, even as many as have believed in my name, for I am Christ, and in mine own name, by the virtue of the blood which I have spilt, have I pleaded before the Father for them.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 38:5",
+							"text": "But behold, the residue of the wicked have I kept in chains of darkness until the judgment of the great day, which shall come at the end of the earth;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 38:6",
+							"text": "And even so will I cause the wicked to be kept, that will not hear my voice but harden their hearts, and wo, wo, wo, is their doom.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 38:7",
+							"text": "But behold, verily, verily, I say unto you that mine eyes are upon you. I am in your midst and ye cannot see me;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 38:8",
+							"text": "But the day soon cometh that ye shall see me, and know that I am; for the veil of darkness shall soon be rent, and he that is not purified shall not abide the day.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 38:9",
+							"text": "Wherefore, gird up your loins and be prepared. Behold, the kingdom is yours, and the enemy shall not overcome.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 38:10",
+							"text": "Verily I say unto you, ye are clean, but not all; and there is none else with whom I am well pleased;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 38:11",
+							"text": "For all flesh is corrupted before me; and the powers of darkness prevail upon the earth, among the children of men, in the presence of all the hosts of heaven\u2014",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 38:12",
+							"text": "Which causeth silence to reign, and all eternity is pained, and the angels are waiting the great command to reap down the earth, to gather the tares that they may be burned; and, behold, the enemy is combined.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 38:13",
+							"text": "And now I show unto you a mystery, a thing which is had in secret chambers, to bring to pass even your destruction in process of time, and ye knew it not;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 38:14",
+							"text": "But now I tell it unto you, and ye are blessed, not because of your iniquity, neither your hearts of unbelief; for verily some of you are guilty before me, but I will be merciful unto your weakness.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 38:15",
+							"text": "Therefore, be ye strong from henceforth; fear not, for the kingdom is yours.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 38:16",
+							"text": "And for your salvation I give unto you a commandment, for I have heard your prayers, and the poor have complained before me, and the rich have I made, and all flesh is mine, and I am no respecter of persons.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 38:17",
+							"text": "And I have made the earth rich, and behold it is my footstool, wherefore, again I will stand upon it.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 38:18",
+							"text": "And I hold forth and deign to give unto you greater riches, even a land of promise, a land flowing with milk and honey, upon which there shall be no curse when the Lord cometh;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 38:19",
+							"text": "And I will give it unto you for the land of your inheritance, if you seek it with all your hearts.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 38:20",
+							"text": "And this shall be my covenant with you, ye shall have it for the land of your inheritance, and for the inheritance of your children forever, while the earth shall stand, and ye shall possess it again in eternity, no more to pass away.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 38:21",
+							"text": "But, verily I say unto you that in time ye shall have no king nor ruler, for I will be your king and watch over you.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 38:22",
+							"text": "Wherefore, hear my voice and follow me, and you shall be a free people, and ye shall have no laws but my laws when I come, for I am your lawgiver, and what can stay my hand?",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 38:23",
+							"text": "But, verily I say unto you, teach one another according to the office wherewith I have appointed you;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 38:24",
+							"text": "And let every man esteem his brother as himself, and practice virtue and holiness before me.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 38:25",
+							"text": "And again I say unto you, let every man esteem his brother as himself.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 38:26",
+							"text": "For what man among you having twelve sons, and is no respecter of them, and they serve him obediently, and he saith unto the one: Be thou clothed in robes and sit thou here; and to the other: Be thou clothed in rags and sit thou there\u2014and looketh upon his sons and saith I am just?",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 38:27",
+							"text": "Behold, this I have given unto you as a parable, and it is even as I am. I say unto you, be one; and if ye are not one ye are not mine.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 38:28",
+							"text": "And again, I say unto you that the enemy in the secret chambers seeketh your lives.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 38:29",
+							"text": "Ye hear of wars in far countries, and you say that there will soon be great wars in far countries, but ye know not the hearts of men in your own land.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 38:30",
+							"text": "I tell you these things because of your prayers; wherefore, treasure up wisdom in your bosoms, lest the wickedness of men reveal these things unto you by their wickedness, in a manner which shall speak in your ears with a voice louder than that which shall shake the earth; but if ye are prepared ye shall not fear.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 38:31",
+							"text": "And that ye might escape the power of the enemy, and be gathered unto me a righteous people, without spot and blameless\u2014",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 38:32",
+							"text": "Wherefore, for this cause I gave unto you the commandment that ye should go to the Ohio; and there I will give unto you my law; and there you shall be endowed with power from on high;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 38:33",
+							"text": "And from thence, whosoever I will shall go forth among all nations, and it shall be told them what they shall do; for I have a great work laid up in store, for Israel shall be saved, and I will lead them whithersoever I will, and no power shall stay my hand.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 38:34",
+							"text": "And now, I give unto the church in these parts a commandment, that certain men among them shall be appointed, and they shall be appointed by the voice of the church;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 38:35",
+							"text": "And they shall look to the poor and the needy, and administer to their relief that they shall not suffer; and send them forth to the place which I have commanded them;",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 38:36",
+							"text": "And this shall be their work, to govern the affairs of the property of this church.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 38:37",
+							"text": "And they that have farms that cannot be sold, let them be left or rented as seemeth them good.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 38:38",
+							"text": "See that all things are preserved; and when men are endowed with power from on high and sent forth, all these things shall be gathered unto the bosom of the church.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 38:39",
+							"text": "And if ye seek the riches which it is the will of the Father to give unto you, ye shall be the richest of all people, for ye shall have the riches of eternity; and it must needs be that the riches of the earth are mine to give; but beware of pride, lest ye become as the Nephites of old.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 38:40",
+							"text": "And again, I say unto you, I give unto you a commandment, that every man, both elder, priest, teacher, and also member, go to with his might, with the labor of his hands, to prepare and accomplish the things which I have commanded.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 38:41",
+							"text": "And let your preaching be the warning voice, every man to his neighbor, in mildness and in meekness.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 38:42",
+							"text": "And go ye out from among the wicked. Save yourselves. Be ye clean that bear the vessels of the Lord. Even so. Amen.",
+							"verse": 42
+						}
+					]
+				},
+				{
+					"chapter": 39,
+					"reference": "D&C 39",
+					"verses": [{
+							"reference": "D&C 39:1",
+							"text": "Hearken and listen to the voice of him who is from all eternity to all eternity, the Great I AM, even Jesus Christ\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 39:2",
+							"text": "The light and the life of the world; a light which shineth in darkness and the darkness comprehendeth it not;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 39:3",
+							"text": "The same which came in the meridian of time unto mine own, and mine own received me not;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 39:4",
+							"text": "But to as many as received me, gave I power to become my sons; and even so will I give unto as many as will receive me, power to become my sons.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 39:5",
+							"text": "And verily, verily, I say unto you, he that receiveth my gospel receiveth me; and he that receiveth not my gospel receiveth not me.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 39:6",
+							"text": "And this is my gospel\u2014repentance and baptism by water, and then cometh the baptism of fire and the Holy Ghost, even the Comforter, which showeth all things, and teacheth the peaceable things of the kingdom.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 39:7",
+							"text": "And now, behold, I say unto you, my servant James, I have looked upon thy works and I know thee.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 39:8",
+							"text": "And verily I say unto thee, thine heart is now right before me at this time; and, behold, I have bestowed great blessings upon thy head;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 39:9",
+							"text": "Nevertheless, thou hast seen great sorrow, for thou hast rejected me many times because of pride and the cares of the world.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 39:10",
+							"text": "But, behold, the days of thy deliverance are come, if thou wilt hearken to my voice, which saith unto thee: Arise and be baptized, and wash away your sins, calling on my name, and you shall receive my Spirit, and a blessing so great as you never have known.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 39:11",
+							"text": "And if thou do this, I have prepared thee for a greater work. Thou shalt preach the fulness of my gospel, which I have sent forth in these last days, the covenant which I have sent forth to recover my people, which are of the house of Israel.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 39:12",
+							"text": "And it shall come to pass that power shall rest upon thee; thou shalt have great faith, and I will be with thee and go before thy face.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 39:13",
+							"text": "Thou art called to labor in my vineyard, and to build up my church, and to bring forth Zion, that it may rejoice upon the hills and flourish.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 39:14",
+							"text": "Behold, verily, verily, I say unto thee, thou art not called to go into the eastern countries, but thou art called to go to the Ohio.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 39:15",
+							"text": "And inasmuch as my people shall assemble themselves at the Ohio, I have kept in store a blessing such as is not known among the children of men, and it shall be poured forth upon their heads. And from thence men shall go forth into all nations.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 39:16",
+							"text": "Behold, verily, verily, I say unto you, that the people in Ohio call upon me in much faith, thinking I will stay my hand in judgment upon the nations, but I cannot deny my word.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 39:17",
+							"text": "Wherefore lay to with your might and call faithful laborers into my vineyard, that it may be pruned for the last time.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 39:18",
+							"text": "And inasmuch as they do repent and receive the fulness of my gospel, and become sanctified, I will stay mine hand in judgment.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 39:19",
+							"text": "Wherefore, go forth, crying with a loud voice, saying: The kingdom of heaven is at hand; crying: Hosanna! blessed be the name of the Most High God.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 39:20",
+							"text": "Go forth baptizing with water, preparing the way before my face for the time of my coming;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 39:21",
+							"text": "For the time is at hand; the day or the hour no man knoweth; but it surely shall come.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 39:22",
+							"text": "And he that receiveth these things receiveth me; and they shall be gathered unto me in time and in eternity.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 39:23",
+							"text": "And again, it shall come to pass that on as many as ye shall baptize with water, ye shall lay your hands, and they shall receive the gift of the Holy Ghost, and shall be looking forth for the signs of my coming, and shall know me.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 39:24",
+							"text": "Behold, I come quickly. Even so. Amen.",
+							"verse": 24
+						}
+					]
+				},
+				{
+					"chapter": 40,
+					"reference": "D&C 40",
+					"verses": [{
+							"reference": "D&C 40:1",
+							"text": "Behold, verily I say unto you, that the heart of my servant James Covel was right before me, for he covenanted with me that he would obey my word.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 40:2",
+							"text": "And he received the word with gladness, but straightway Satan tempted him; and the fear of persecution and the cares of the world caused him to reject the word.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 40:3",
+							"text": "Wherefore he broke my covenant, and it remaineth with me to do with him as seemeth me good. Amen.",
+							"verse": 3
+						}
+					]
+				},
+				{
+					"chapter": 41,
+					"reference": "D&C 41",
+					"verses": [{
+							"reference": "D&C 41:1",
+							"text": "Hearken and hear, O ye my people, saith the Lord and your God, ye whom I delight to bless with the greatest of all blessings, ye that hear me; and ye that hear me not will I curse, that have professed my name, with the heaviest of all cursings.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 41:2",
+							"text": "Hearken, O ye elders of my church whom I have called, behold I give unto you a commandment, that ye shall assemble yourselves together to agree upon my word;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 41:3",
+							"text": "And by the prayer of your faith ye shall receive my law, that ye may know how to govern my church and have all things right before me.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 41:4",
+							"text": "And I will be your ruler when I come; and behold, I come quickly, and ye shall see that my law is kept.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 41:5",
+							"text": "He that receiveth my law and doeth it, the same is my disciple; and he that saith he receiveth it and doeth it not, the same is not my disciple, and shall be cast out from among you;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 41:6",
+							"text": "For it is not meet that the things which belong to the children of the kingdom should be given to them that are not worthy, or to dogs, or the pearls to be cast before swine.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 41:7",
+							"text": "And again, it is meet that my servant Joseph Smith, Jun., should have a house built, in which to live and translate.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 41:8",
+							"text": "And again, it is meet that my servant Sidney Rigdon should live as seemeth him good, inasmuch as he keepeth my commandments.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 41:9",
+							"text": "And again, I have called my servant Edward Partridge; and I give a commandment, that he should be appointed by the voice of the church, and ordained a bishop unto the church, to leave his merchandise and to spend all his time in the labors of the church;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 41:10",
+							"text": "To see to all things as it shall be appointed unto him in my laws in the day that I shall give them.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 41:11",
+							"text": "And this because his heart is pure before me, for he is like unto Nathanael of old, in whom there is no guile.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 41:12",
+							"text": "These words are given unto you, and they are pure before me; wherefore, beware how you hold them, for they are to be answered upon your souls in the day of judgment. Even so. Amen.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 42,
+					"reference": "D&C 42",
+					"verses": [{
+							"reference": "D&C 42:1",
+							"text": "Hearken, O ye elders of my church, who have assembled yourselves together in my name, even Jesus Christ the Son of the living God, the Savior of the world; inasmuch as ye believe on my name and keep my commandments.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 42:2",
+							"text": "Again I say unto you, hearken and hear and obey the law which I shall give unto you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 42:3",
+							"text": "For verily I say, as ye have assembled yourselves together according to the commandment wherewith I commanded you, and are agreed as touching this one thing, and have asked the Father in my name, even so ye shall receive.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 42:4",
+							"text": "Behold, verily I say unto you, I give unto you this first commandment, that ye shall go forth in my name, every one of you, excepting my servants Joseph Smith, Jun., and Sidney Rigdon.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 42:5",
+							"text": "And I give unto them a commandment that they shall go forth for a little season, and it shall be given by the power of the Spirit when they shall return.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 42:6",
+							"text": "And ye shall go forth in the power of my Spirit, preaching my gospel, two by two, in my name, lifting up your voices as with the sound of a trump, declaring my word like unto angels of God.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 42:7",
+							"text": "And ye shall go forth baptizing with water, saying: Repent ye, repent ye, for the kingdom of heaven is at hand.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 42:8",
+							"text": "And from this place ye shall go forth into the regions westward; and inasmuch as ye shall find them that will receive you ye shall build up my church in every region\u2014",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 42:9",
+							"text": "Until the time shall come when it shall be revealed unto you from on high, when the city of the New Jerusalem shall be prepared, that ye may be gathered in one, that ye may be my people and I will be your God.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 42:10",
+							"text": "And again, I say unto you, that my servant Edward Partridge shall stand in the office whereunto I have appointed him. And it shall come to pass, that if he transgress another shall be appointed in his stead. Even so. Amen.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 42:11",
+							"text": "Again I say unto you, that it shall not be given to any one to go forth to preach my gospel, or to build up my church, except he be ordained by some one who has authority, and it is known to the church that he has authority and has been regularly ordained by the heads of the church.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 42:12",
+							"text": "And again, the elders, priests and teachers of this church shall teach the principles of my gospel, which are in the Bible and the Book of Mormon, in the which is the fulness of the gospel.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 42:13",
+							"text": "And they shall observe the covenants and church articles to do them, and these shall be their teachings, as they shall be directed by the Spirit.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 42:14",
+							"text": "And the Spirit shall be given unto you by the prayer of faith; and if ye receive not the Spirit ye shall not teach.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 42:15",
+							"text": "And all this ye shall observe to do as I have commanded concerning your teaching, until the fulness of my scriptures is given.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 42:16",
+							"text": "And as ye shall lift up your voices by the Comforter, ye shall speak and prophesy as seemeth me good;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 42:17",
+							"text": "For, behold, the Comforter knoweth all things, and beareth record of the Father and of the Son.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 42:18",
+							"text": "And now, behold, I speak unto the church. Thou shalt not kill; and he that kills shall not have forgiveness in this world, nor in the world to come.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 42:19",
+							"text": "And again, I say, thou shalt not kill; but he that killeth shall die.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 42:20",
+							"text": "Thou shalt not steal; and he that stealeth and will not repent shall be cast out.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 42:21",
+							"text": "Thou shalt not lie; he that lieth and will not repent shall be cast out.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 42:22",
+							"text": "Thou shalt love thy wife with all thy heart, and shalt cleave unto her and none else.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 42:23",
+							"text": "And he that looketh upon a woman to lust after her shall deny the faith, and shall not have the Spirit; and if he repents not he shall be cast out.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 42:24",
+							"text": "Thou shalt not commit adultery; and he that committeth adultery, and repenteth not, shall be cast out.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 42:25",
+							"text": "But he that has committed adultery and repents with all his heart, and forsaketh it, and doeth it no more, thou shalt forgive;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 42:26",
+							"text": "But if he doeth it again, he shall not be forgiven, but shall be cast out.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 42:27",
+							"text": "Thou shalt not speak evil of thy neighbor, nor do him any harm.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 42:28",
+							"text": "Thou knowest my laws concerning these things are given in my scriptures; he that sinneth and repenteth not shall be cast out.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 42:29",
+							"text": "If thou lovest me thou shalt serve me and keep all my commandments.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 42:30",
+							"text": "And behold, thou wilt remember the poor, and consecrate of thy properties for their support that which thou hast to impart unto them, with a covenant and a deed which cannot be broken.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 42:31",
+							"text": "And inasmuch as ye impart of your substance unto the poor, ye will do it unto me; and they shall be laid before the bishop of my church and his counselors, two of the elders, or high priests, such as he shall appoint or has appointed and set apart for that purpose.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 42:32",
+							"text": "And it shall come to pass, that after they are laid before the bishop of my church, and after that he has received these testimonies concerning the consecration of the properties of my church, that they cannot be taken from the church, agreeable to my commandments, every man shall be made accountable unto me, a steward over his own property, or that which he has received by consecration, as much as is sufficient for himself and family.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 42:33",
+							"text": "And again, if there shall be properties in the hands of the church, or any individuals of it, more than is necessary for their support after this first consecration, which is a residue to be consecrated unto the bishop, it shall be kept to administer to those who have not, from time to time, that every man who has need may be amply supplied and receive according to his wants.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 42:34",
+							"text": "Therefore, the residue shall be kept in my storehouse, to administer to the poor and the needy, as shall be appointed by the high council of the church, and the bishop and his council;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 42:35",
+							"text": "And for the purpose of purchasing lands for the public benefit of the church, and building houses of worship, and building up of the New Jerusalem which is hereafter to be revealed\u2014",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 42:36",
+							"text": "That my covenant people may be gathered in one in that day when I shall come to my temple. And this I do for the salvation of my people.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 42:37",
+							"text": "And it shall come to pass, that he that sinneth and repenteth not shall be cast out of the church, and shall not receive again that which he has consecrated unto the poor and the needy of my church, or in other words, unto me\u2014",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 42:38",
+							"text": "For inasmuch as ye do it unto the least of these, ye do it unto me.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 42:39",
+							"text": "For it shall come to pass, that which I spake by the mouths of my prophets shall be fulfilled; for I will consecrate of the riches of those who embrace my gospel among the Gentiles unto the poor of my people who are of the house of Israel.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 42:40",
+							"text": "And again, thou shalt not be proud in thy heart; let all thy garments be plain, and their beauty the beauty of the work of thine own hands;",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 42:41",
+							"text": "And let all things be done in cleanliness before me.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 42:42",
+							"text": "Thou shalt not be idle; for he that is idle shall not eat the bread nor wear the garments of the laborer.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 42:43",
+							"text": "And whosoever among you are sick, and have not faith to be healed, but believe, shall be nourished with all tenderness, with herbs and mild food, and that not by the hand of an enemy.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 42:44",
+							"text": "And the elders of the church, two or more, shall be called, and shall pray for and lay their hands upon them in my name; and if they die they shall die unto me, and if they live they shall live unto me.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 42:45",
+							"text": "Thou shalt live together in love, insomuch that thou shalt weep for the loss of them that die, and more especially for those that have not hope of a glorious resurrection.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 42:46",
+							"text": "And it shall come to pass that those that die in me shall not taste of death, for it shall be sweet unto them;",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 42:47",
+							"text": "And they that die not in me, wo unto them, for their death is bitter.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 42:48",
+							"text": "And again, it shall come to pass that he that hath faith in me to be healed, and is not appointed unto death, shall be healed.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 42:49",
+							"text": "He who hath faith to see shall see.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 42:50",
+							"text": "He who hath faith to hear shall hear.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 42:51",
+							"text": "The lame who hath faith to leap shall leap.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 42:52",
+							"text": "And they who have not faith to do these things, but believe in me, have power to become my sons; and inasmuch as they break not my laws thou shalt bear their infirmities.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 42:53",
+							"text": "Thou shalt stand in the place of thy stewardship.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 42:54",
+							"text": "Thou shalt not take thy brother's garment; thou shalt pay for that which thou shalt receive of thy brother.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 42:55",
+							"text": "And if thou obtainest more than that which would be for thy support, thou shalt give it into my storehouse, that all things may be done according to that which I have said.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 42:56",
+							"text": "Thou shalt ask, and my scriptures shall be given as I have appointed, and they shall be preserved in safety;",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 42:57",
+							"text": "And it is expedient that thou shouldst hold thy peace concerning them, and not teach them until ye have received them in full.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 42:58",
+							"text": "And I give unto you a commandment that then ye shall teach them unto all men; for they shall be taught unto all nations, kindreds, tongues and people.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 42:59",
+							"text": "Thou shalt take the things which thou hast received, which have been given unto thee in my scriptures for a law, to be my law to govern my church;",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 42:60",
+							"text": "And he that doeth according to these things shall be saved, and he that doeth them not shall be damned if he so continue.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 42:61",
+							"text": "If thou shalt ask, thou shalt receive revelation upon revelation, knowledge upon knowledge, that thou mayest know the mysteries and peaceable things\u2014that which bringeth joy, that which bringeth life eternal.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 42:62",
+							"text": "Thou shalt ask, and it shall be revealed unto you in mine own due time where the New Jerusalem shall be built.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 42:63",
+							"text": "And behold, it shall come to pass that my servants shall be sent forth to the east and to the west, to the north and to the south.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 42:64",
+							"text": "And even now, let him that goeth to the east teach them that shall be converted to flee to the west, and this in consequence of that which is coming on the earth, and of secret combinations.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 42:65",
+							"text": "Behold, thou shalt observe all these things, and great shall be thy reward; for unto you it is given to know the mysteries of the kingdom, but unto the world it is not given to know them.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 42:66",
+							"text": "Ye shall observe the laws which ye have received and be faithful.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 42:67",
+							"text": "And ye shall hereafter receive church covenants, such as shall be sufficient to establish you, both here and in the New Jerusalem.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 42:68",
+							"text": "Therefore, he that lacketh wisdom, let him ask of me, and I will give him liberally and upbraid him not.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 42:69",
+							"text": "Lift up your hearts and rejoice, for unto you the kingdom, or in other words, the keys of the church have been given. Even so. Amen.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 42:70",
+							"text": "The priests and teachers shall have their stewardships, even as the members.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 42:71",
+							"text": "And the elders or high priests who are appointed to assist the bishop as counselors in all things, are to have their families supported out of the property which is consecrated to the bishop, for the good of the poor, and for other purposes, as before mentioned;",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 42:72",
+							"text": "Or they are to receive a just remuneration for all their services, either a stewardship or otherwise, as may be thought best or decided by the counselors and bishop.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 42:73",
+							"text": "And the bishop, also, shall receive his support, or a just remuneration for all his services in the church.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 42:74",
+							"text": "Behold, verily I say unto you, that whatever persons among you, having put away their companions for the cause of fornication, or in other words, if they shall testify before you in all lowliness of heart that this is the case, ye shall not cast them out from among you;",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 42:75",
+							"text": "But if ye shall find that any persons have left their companions for the sake of adultery, and they themselves are the offenders, and their companions are living, they shall be cast out from among you.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 42:76",
+							"text": "And again, I say unto you, that ye shall be watchful and careful, with all inquiry, that ye receive none such among you if they are married;",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 42:77",
+							"text": "And if they are not married, they shall repent of all their sins or ye shall not receive them.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 42:78",
+							"text": "And again, every person who belongeth to this church of Christ, shall observe to keep all the commandments and covenants of the church.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 42:79",
+							"text": "And it shall come to pass, that if any persons among you shall kill they shall be delivered up and dealt with according to the laws of the land; for remember that he hath no forgiveness; and it shall be proved according to the laws of the land.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 42:80",
+							"text": "And if any man or woman shall commit adultery, he or she shall be tried before two elders of the church, or more, and every word shall be established against him or her by two witnesses of the church, and not of the enemy; but if there are more than two witnesses it is better.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 42:81",
+							"text": "But he or she shall be condemned by the mouth of two witnesses; and the elders shall lay the case before the church, and the church shall lift up their hands against him or her, that they may be dealt with according to the law of God.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 42:82",
+							"text": "And if it can be, it is necessary that the bishop be present also.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 42:83",
+							"text": "And thus ye shall do in all cases which shall come before you.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 42:84",
+							"text": "And if a man or woman shall rob, he or she shall be delivered up unto the law of the land.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 42:85",
+							"text": "And if he or she shall steal, he or she shall be delivered up unto the law of the land.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 42:86",
+							"text": "And if he or she shall lie, he or she shall be delivered up unto the law of the land.",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 42:87",
+							"text": "And if he or she do any manner of iniquity, he or she shall be delivered up unto the law, even that of God.",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 42:88",
+							"text": "And if thy brother or sister offend thee, thou shalt take him or her between him or her and thee alone; and if he or she confess thou shalt be reconciled.",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 42:89",
+							"text": "And if he or she confess not thou shalt deliver him or her up unto the church, not to the members, but to the elders. And it shall be done in a meeting, and that not before the world.",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 42:90",
+							"text": "And if thy brother or sister offend many, he or she shall be chastened before many.",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 42:91",
+							"text": "And if any one offend openly, he or she shall be rebuked openly, that he or she may be ashamed. And if he or she confess not, he or she shall be delivered up unto the law of God.",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 42:92",
+							"text": "If any shall offend in secret, he or she shall be rebuked in secret, that he or she may have opportunity to confess in secret to him or her whom he or she has offended, and to God, that the church may not speak reproachfully of him or her.",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 42:93",
+							"text": "And thus shall ye conduct in all things.",
+							"verse": 93
+						}
+					]
+				},
+				{
+					"chapter": 43,
+					"reference": "D&C 43",
+					"verses": [{
+							"reference": "D&C 43:1",
+							"text": "O hearken, ye elders of my church, and give ear to the words which I shall speak unto you.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 43:2",
+							"text": "For behold, verily, verily, I say unto you, that ye have received a commandment for a law unto my church, through him whom I have appointed unto you to receive commandments and revelations from my hand.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 43:3",
+							"text": "And this ye shall know assuredly\u2014that there is none other appointed unto you to receive commandments and revelations until he be taken, if he abide in me.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 43:4",
+							"text": "But verily, verily, I say unto you, that none else shall be appointed unto this gift except it be through him; for if it be taken from him he shall not have power except to appoint another in his stead.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 43:5",
+							"text": "And this shall be a law unto you, that ye receive not the teachings of any that shall come before you as revelations or commandments;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 43:6",
+							"text": "And this I give unto you that you may not be deceived, that you may know they are not of me.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 43:7",
+							"text": "For verily I say unto you, that he that is ordained of me shall come in at the gate and be ordained as I have told you before, to teach those revelations which you have received and shall receive through him whom I have appointed.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 43:8",
+							"text": "And now, behold, I give unto you a commandment, that when ye are assembled together ye shall instruct and edify each other, that ye may know how to act and direct my church, how to act upon the points of my law and commandments, which I have given.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 43:9",
+							"text": "And thus ye shall become instructed in the law of my church, and be sanctified by that which ye have received, and ye shall bind yourselves to act in all holiness before me\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 43:10",
+							"text": "That inasmuch as ye do this, glory shall be added to the kingdom which ye have received. Inasmuch as ye do it not, it shall be taken, even that which ye have received.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 43:11",
+							"text": "Purge ye out the iniquity which is among you; sanctify yourselves before me;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 43:12",
+							"text": "And if ye desire the glories of the kingdom, appoint ye my servant Joseph Smith, Jun., and uphold him before me by the prayer of faith.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 43:13",
+							"text": "And again, I say unto you, that if ye desire the mysteries of the kingdom, provide for him food and raiment, and whatsoever thing he needeth to accomplish the work wherewith I have commanded him;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 43:14",
+							"text": "And if ye do it not he shall remain unto them that have received him, that I may reserve unto myself a pure people before me.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 43:15",
+							"text": "Again I say, hearken ye elders of my church, whom I have appointed: Ye are not sent forth to be taught, but to teach the children of men the things which I have put into your hands by the power of my Spirit;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 43:16",
+							"text": "And ye are to be taught from on high. Sanctify yourselves and ye shall be endowed with power, that ye may give even as I have spoken.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 43:17",
+							"text": "Hearken ye, for, behold, the great day of the Lord is nigh at hand.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 43:18",
+							"text": "For the day cometh that the Lord shall utter his voice out of heaven; the heavens shall shake and the earth shall tremble, and the trump of God shall sound both long and loud, and shall say to the sleeping nations: Ye saints arise and live; ye sinners stay and sleep until I shall call again.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 43:19",
+							"text": "Wherefore gird up your loins lest ye be found among the wicked.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 43:20",
+							"text": "Lift up your voices and spare not. Call upon the nations to repent, both old and young, both bond and free, saying: Prepare yourselves for the great day of the Lord;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 43:21",
+							"text": "For if I, who am a man, do lift up my voice and call upon you to repent, and ye hate me, what will ye say when the day cometh when the thunders shall utter their voices from the ends of the earth, speaking to the ears of all that live, saying\u2014Repent, and prepare for the great day of the Lord?",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 43:22",
+							"text": "Yea, and again, when the lightnings shall streak forth from the east unto the west, and shall utter forth their voices unto all that live, and make the ears of all tingle that hear, saying these words\u2014Repent ye, for the great day of the Lord is come?",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 43:23",
+							"text": "And again, the Lord shall utter his voice out of heaven, saying: Hearken, O ye nations of the earth, and hear the words of that God who made you.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 43:24",
+							"text": "O, ye nations of the earth, how often would I have gathered you together as a hen gathereth her chickens under her wings, but ye would not!",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 43:25",
+							"text": "How oft have I called upon you by the mouth of my servants, and by the ministering of angels, and by mine own voice, and by the voice of thunderings, and by the voice of lightnings, and by the voice of tempests, and by the voice of earthquakes, and great hailstorms, and by the voice of famines and pestilences of every kind, and by the great sound of a trump, and by the voice of judgment, and by the voice of mercy all the day long, and by the voice of glory and honor and the riches of eternal life, and would have saved you with an everlasting salvation, but ye would not!",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 43:26",
+							"text": "Behold, the day has come, when the cup of the wrath of mine indignation is full.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 43:27",
+							"text": "Behold, verily I say unto you, that these are the words of the Lord your God.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 43:28",
+							"text": "Wherefore, labor ye, labor ye in my vineyard for the last time\u2014for the last time call upon the inhabitants of the earth.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 43:29",
+							"text": "For in mine own due time will I come upon the earth in judgment, and my people shall be redeemed and shall reign with me on earth.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 43:30",
+							"text": "For the great Millennium, of which I have spoken by the mouth of my servants, shall come.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 43:31",
+							"text": "For Satan shall be bound, and when he is loosed again he shall only reign for a little season, and then cometh the end of the earth.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 43:32",
+							"text": "And he that liveth in righteousness shall be changed in the twinkling of an eye, and the earth shall pass away so as by fire.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 43:33",
+							"text": "And the wicked shall go away into unquenchable fire, and their end no man knoweth on earth, nor ever shall know, until they come before me in judgment.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 43:34",
+							"text": "Hearken ye to these words. Behold, I am Jesus Christ, the Savior of the world. Treasure these things up in your hearts, and let the solemnities of eternity rest upon your minds.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 43:35",
+							"text": "Be sober. Keep all my commandments. Even so. Amen.",
+							"verse": 35
+						}
+					]
+				},
+				{
+					"chapter": 44,
+					"reference": "D&C 44",
+					"verses": [{
+							"reference": "D&C 44:1",
+							"text": "Behold, thus saith the Lord unto you my servants, it is expedient in me that the elders of my church should be called together, from the east and from the west, and from the north and from the south, by letter or some other way.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 44:2",
+							"text": "And it shall come to pass, that inasmuch as they are faithful, and exercise faith in me, I will pour out my Spirit upon them in the day that they assemble themselves together.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 44:3",
+							"text": "And it shall come to pass that they shall go forth into the regions round about, and preach repentance unto the people.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 44:4",
+							"text": "And many shall be converted, insomuch that ye shall obtain power to organize yourselves according to the laws of man;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 44:5",
+							"text": "That your enemies may not have power over you; that you may be preserved in all things; that you may be enabled to keep my laws; that every bond may be broken wherewith the enemy seeketh to destroy my people.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 44:6",
+							"text": "Behold, I say unto you, that ye must visit the poor and the needy and administer to their relief, that they may be kept until all things may be done according to my law which ye have received. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 45,
+					"reference": "D&C 45",
+					"verses": [{
+							"reference": "D&C 45:1",
+							"text": "Hearken, O ye people of my church, to whom the kingdom has been given; hearken ye and give ear to him who laid the foundation of the earth, who made the heavens and all the hosts thereof, and by whom all things were made which live, and move, and have a being.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 45:2",
+							"text": "And again I say, hearken unto my voice, lest death shall overtake you; in an hour when ye think not the summer shall be past, and the harvest ended, and your souls not saved.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 45:3",
+							"text": "Listen to him who is the advocate with the Father, who is pleading your cause before him\u2014",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 45:4",
+							"text": "Saying: Father, behold the sufferings and death of him who did no sin, in whom thou wast well pleased; behold the blood of thy Son which was shed, the blood of him whom thou gavest that thyself might be glorified;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 45:5",
+							"text": "Wherefore, Father, spare these my brethren that believe on my name, that they may come unto me and have everlasting life.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 45:6",
+							"text": "Hearken, O ye people of my church, and ye elders listen together, and hear my voice while it is called today, and harden not your hearts;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 45:7",
+							"text": "For verily I say unto you that I am Alpha and Omega, the beginning and the end, the light and the life of the world\u2014a light that shineth in darkness and the darkness comprehendeth it not.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 45:8",
+							"text": "I came unto mine own, and mine own received me not; but unto as many as received me gave I power to do many miracles, and to become the sons of God; and even unto them that believed on my name gave I power to obtain eternal life.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 45:9",
+							"text": "And even so I have sent mine everlasting covenant into the world, to be a light to the world, and to be a standard for my people, and for the Gentiles to seek to it, and to be a messenger before my face to prepare the way before me.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 45:10",
+							"text": "Wherefore, come ye unto it, and with him that cometh I will reason as with men in days of old, and I will show unto you my strong reasoning.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 45:11",
+							"text": "Wherefore, hearken ye together and let me show unto you even my wisdom\u2014the wisdom of him whom ye say is the God of Enoch, and his brethren,",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 45:12",
+							"text": "Who were separated from the earth, and were received unto myself\u2014a city reserved until a day of righteousness shall come\u2014a day which was sought for by all holy men, and they found it not because of wickedness and abominations;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 45:13",
+							"text": "And confessed they were strangers and pilgrims on the earth;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 45:14",
+							"text": "But obtained a promise that they should find it and see it in their flesh.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 45:15",
+							"text": "Wherefore, hearken and I will reason with you, and I will speak unto you and prophesy, as unto men in days of old.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 45:16",
+							"text": "And I will show it plainly as I showed it unto my disciples as I stood before them in the flesh, and spake unto them, saying: As ye have asked of me concerning the signs of my coming, in the day when I shall come in my glory in the clouds of heaven, to fulfil the promises that I have made unto your fathers,",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 45:17",
+							"text": "For as ye have looked upon the long absence of your spirits from your bodies to be a bondage, I will show unto you how the day of redemption shall come, and also the restoration of the scattered Israel.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 45:18",
+							"text": "And now ye behold this temple which is in Jerusalem, which ye call the house of God, and your enemies say that this house shall never fall.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 45:19",
+							"text": "But, verily I say unto you, that desolation shall come upon this generation as a thief in the night, and this people shall be destroyed and scattered among all nations.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 45:20",
+							"text": "And this temple which ye now see shall be thrown down that there shall not be left one stone upon another.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 45:21",
+							"text": "And it shall come to pass, that this generation of Jews shall not pass away until every desolation which I have told you concerning them shall come to pass.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 45:22",
+							"text": "Ye say that ye know that the end of the world cometh; ye say also that ye know that the heavens and the earth shall pass away;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 45:23",
+							"text": "And in this ye say truly, for so it is; but these things which I have told you shall not pass away until all shall be fulfilled.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 45:24",
+							"text": "And this I have told you concerning Jerusalem; and when that day shall come, shall a remnant be scattered among all nations;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 45:25",
+							"text": "But they shall be gathered again; but they shall remain until the times of the Gentiles be fulfilled.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 45:26",
+							"text": "And in that day shall be heard of wars and rumors of wars, and the whole earth shall be in commotion, and men's hearts shall fail them, and they shall say that Christ delayeth his coming until the end of the earth.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 45:27",
+							"text": "And the love of men shall wax cold, and iniquity shall abound.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 45:28",
+							"text": "And when the times of the Gentiles is come in, a light shall break forth among them that sit in darkness, and it shall be the fulness of my gospel;",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 45:29",
+							"text": "But they receive it not; for they perceive not the light, and they turn their hearts from me because of the precepts of men.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 45:30",
+							"text": "And in that generation shall the times of the Gentiles be fulfilled.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 45:31",
+							"text": "And there shall be men standing in that generation, that shall not pass until they shall see an overflowing scourge; for a desolating sickness shall cover the land.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 45:32",
+							"text": "But my disciples shall stand in holy places, and shall not be moved; but among the wicked, men shall lift up their voices and curse God and die.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 45:33",
+							"text": "And there shall be earthquakes also in divers places, and many desolations; yet men will harden their hearts against me, and they will take up the sword, one against another, and they will kill one another.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 45:34",
+							"text": "And now, when I the Lord had spoken these words unto my disciples, they were troubled.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 45:35",
+							"text": "And I said unto them: Be not troubled, for, when all these things shall come to pass, ye may know that the promises which have been made unto you shall be fulfilled.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 45:36",
+							"text": "And when the light shall begin to break forth, it shall be with them like unto a parable which I will show you\u2014",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 45:37",
+							"text": "Ye look and behold the fig trees, and ye see them with your eyes, and ye say when they begin to shoot forth, and their leaves are yet tender, that summer is now nigh at hand;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 45:38",
+							"text": "Even so it shall be in that day when they shall see all these things, then shall they know that the hour is nigh.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 45:39",
+							"text": "And it shall come to pass that he that feareth me shall be looking forth for the great day of the Lord to come, even for the signs of the coming of the Son of Man.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 45:40",
+							"text": "And they shall see signs and wonders, for they shall be shown forth in the heavens above, and in the earth beneath.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 45:41",
+							"text": "And they shall behold blood, and fire, and vapors of smoke.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 45:42",
+							"text": "And before the day of the Lord shall come, the sun shall be darkened, and the moon be turned into blood, and the stars fall from heaven.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 45:43",
+							"text": "And the remnant shall be gathered unto this place;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 45:44",
+							"text": "And then they shall look for me, and, behold, I will come; and they shall see me in the clouds of heaven, clothed with power and great glory; with all the holy angels; and he that watches not for me shall be cut off.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 45:45",
+							"text": "But before the arm of the Lord shall fall, an angel shall sound his trump, and the saints that have slept shall come forth to meet me in the cloud.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 45:46",
+							"text": "Wherefore, if ye have slept in peace blessed are you; for as you now behold me and know that I am, even so shall ye come unto me and your souls shall live, and your redemption shall be perfected; and the saints shall come forth from the four quarters of the earth.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 45:47",
+							"text": "Then shall the arm of the Lord fall upon the nations.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 45:48",
+							"text": "And then shall the Lord set his foot upon this mount, and it shall cleave in twain, and the earth shall tremble, and reel to and fro, and the heavens also shall shake.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 45:49",
+							"text": "And the Lord shall utter his voice, and all the ends of the earth shall hear it; and the nations of the earth shall mourn, and they that have laughed shall see their folly.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 45:50",
+							"text": "And calamity shall cover the mocker, and the scorner shall be consumed; and they that have watched for iniquity shall be hewn down and cast into the fire.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 45:51",
+							"text": "And then shall the Jews look upon me and say: What are these wounds in thine hands and in thy feet?",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 45:52",
+							"text": "Then shall they know that I am the Lord; for I will say unto them: These wounds are the wounds with which I was wounded in the house of my friends. I am he who was lifted up. I am Jesus that was crucified. I am the Son of God.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 45:53",
+							"text": "And then shall they weep because of their iniquities; then shall they lament because they persecuted their king.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 45:54",
+							"text": "And then shall the heathen nations be redeemed, and they that knew no law shall have part in the first resurrection; and it shall be tolerable for them.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 45:55",
+							"text": "And Satan shall be bound, that he shall have no place in the hearts of the children of men.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 45:56",
+							"text": "And at that day, when I shall come in my glory, shall the parable be fulfilled which I spake concerning the ten virgins.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 45:57",
+							"text": "For they that are wise and have received the truth, and have taken the Holy Spirit for their guide, and have not been deceived\u2014verily I say unto you, they shall not be hewn down and cast into the fire, but shall abide the day.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 45:58",
+							"text": "And the earth shall be given unto them for an inheritance; and they shall multiply and wax strong, and their children shall grow up without sin unto salvation.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 45:59",
+							"text": "For the Lord shall be in their midst, and his glory shall be upon them, and he will be their king and their lawgiver.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 45:60",
+							"text": "And now, behold, I say unto you, it shall not be given unto you to know any further concerning this chapter, until the New Testament be translated, and in it all these things shall be made known;",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 45:61",
+							"text": "Wherefore I give unto you that ye may now translate it, that ye may be prepared for the things to come.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 45:62",
+							"text": "For verily I say unto you, that great things await you;",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 45:63",
+							"text": "Ye hear of wars in foreign lands; but, behold, I say unto you, they are nigh, even at your doors, and not many years hence ye shall hear of wars in your own lands.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 45:64",
+							"text": "Wherefore I, the Lord, have said, gather ye out from the eastern lands, assemble ye yourselves together ye elders of my church; go ye forth into the western countries, call upon the inhabitants to repent, and inasmuch as they do repent, build up churches unto me.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 45:65",
+							"text": "And with one heart and with one mind, gather up your riches that ye may purchase an inheritance which shall hereafter be appointed unto you.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 45:66",
+							"text": "And it shall be called the New Jerusalem, a land of peace, a city of refuge, a place of safety for the saints of the Most High God;",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 45:67",
+							"text": "And the glory of the Lord shall be there, and the terror of the Lord also shall be there, insomuch that the wicked will not come unto it, and it shall be called Zion.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 45:68",
+							"text": "And it shall come to pass among the wicked, that every man that will not take his sword against his neighbor must needs flee unto Zion for safety.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 45:69",
+							"text": "And there shall be gathered unto it out of every nation under heaven; and it shall be the only people that shall not be at war one with another.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 45:70",
+							"text": "And it shall be said among the wicked: Let us not go up to battle against Zion, for the inhabitants of Zion are terrible; wherefore we cannot stand.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 45:71",
+							"text": "And it shall come to pass that the righteous shall be gathered out from among all nations, and shall come to Zion, singing with songs of everlasting joy.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 45:72",
+							"text": "And now I say unto you, keep these things from going abroad unto the world until it is expedient in me, that ye may accomplish this work in the eyes of the people, and in the eyes of your enemies, that they may not know your works until ye have accomplished the thing which I have commanded you;",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 45:73",
+							"text": "That when they shall know it, that they may consider these things.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 45:74",
+							"text": "For when the Lord shall appear he shall be terrible unto them, that fear may seize upon them, and they shall stand afar off and tremble.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 45:75",
+							"text": "And all nations shall be afraid because of the terror of the Lord, and the power of his might. Even so. Amen.",
+							"verse": 75
+						}
+					]
+				},
+				{
+					"chapter": 46,
+					"reference": "D&C 46",
+					"verses": [{
+							"reference": "D&C 46:1",
+							"text": "Hearken, O ye people of my church; for verily I say unto you that these things were spoken unto you for your profit and learning.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 46:2",
+							"text": "But notwithstanding those things which are written, it always has been given to the elders of my church from the beginning, and ever shall be, to conduct all meetings as they are directed and guided by the Holy Spirit.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 46:3",
+							"text": "Nevertheless ye are commanded never to cast any one out from your public meetings, which are held before the world.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 46:4",
+							"text": "Ye are also commanded not to cast any one who belongeth to the church out of your sacrament meetings; nevertheless, if any have trespassed, let him not partake until he makes reconciliation.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 46:5",
+							"text": "And again I say unto you, ye shall not cast any out of your sacrament meetings who are earnestly seeking the kingdom\u2014I speak this concerning those who are not of the church.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 46:6",
+							"text": "And again I say unto you, concerning your confirmation meetings, that if there be any that are not of the church, that are earnestly seeking after the kingdom, ye shall not cast them out.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 46:7",
+							"text": "But ye are commanded in all things to ask of God, who giveth liberally; and that which the Spirit testifies unto you even so I would that ye should do in all holiness of heart, walking uprightly before me, considering the end of your salvation, doing all things with prayer and thanksgiving, that ye may not be seduced by evil spirits, or doctrines of devils, or the commandments of men; for some are of men, and others of devils.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 46:8",
+							"text": "Wherefore, beware lest ye are deceived; and that ye may not be deceived seek ye earnestly the best gifts, always remembering for what they are given;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 46:9",
+							"text": "For verily I say unto you, they are given for the benefit of those who love me and keep all my commandments, and him that seeketh so to do; that all may be benefited that seek or that ask of me, that ask and not for a sign that they may consume it upon their lusts.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 46:10",
+							"text": "And again, verily I say unto you, I would that ye should always remember, and always retain in your minds what those gifts are, that are given unto the church.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 46:11",
+							"text": "For all have not every gift given unto them; for there are many gifts, and to every man is given a gift by the Spirit of God.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 46:12",
+							"text": "To some is given one, and to some is given another, that all may be profited thereby.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 46:13",
+							"text": "To some it is given by the Holy Ghost to know that Jesus Christ is the Son of God, and that he was crucified for the sins of the world.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 46:14",
+							"text": "To others it is given to believe on their words, that they also might have eternal life if they continue faithful.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 46:15",
+							"text": "And again, to some it is given by the Holy Ghost to know the differences of administration, as it will be pleasing unto the same Lord, according as the Lord will, suiting his mercies according to the conditions of the children of men.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 46:16",
+							"text": "And again, it is given by the Holy Ghost to some to know the diversities of operations, whether they be of God, that the manifestations of the Spirit may be given to every man to profit withal.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 46:17",
+							"text": "And again, verily I say unto you, to some is given, by the Spirit of God, the word of wisdom.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 46:18",
+							"text": "To another is given the word of knowledge, that all may be taught to be wise and to have knowledge.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 46:19",
+							"text": "And again, to some it is given to have faith to be healed;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 46:20",
+							"text": "And to others it is given to have faith to heal.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 46:21",
+							"text": "And again, to some is given the working of miracles;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 46:22",
+							"text": "And to others it is given to prophesy;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 46:23",
+							"text": "And to others the discerning of spirits.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 46:24",
+							"text": "And again, it is given to some to speak with tongues;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 46:25",
+							"text": "And to another is given the interpretation of tongues.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 46:26",
+							"text": "And all these gifts come from God, for the benefit of the children of God.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 46:27",
+							"text": "And unto the bishop of the church, and unto such as God shall appoint and ordain to watch over the church and to be elders unto the church, are to have it given unto them to discern all those gifts lest there shall be any among you professing and yet be not of God.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 46:28",
+							"text": "And it shall come to pass that he that asketh in Spirit shall receive in Spirit;",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 46:29",
+							"text": "That unto some it may be given to have all those gifts, that there may be a head, in order that every member may be profited thereby.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 46:30",
+							"text": "He that asketh in the Spirit asketh according to the will of God; wherefore it is done even as he asketh.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 46:31",
+							"text": "And again, I say unto you, all things must be done in the name of Christ, whatsoever you do in the Spirit;",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 46:32",
+							"text": "And ye must give thanks unto God in the Spirit for whatsoever blessing ye are blessed with.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 46:33",
+							"text": "And ye must practice virtue and holiness before me continually. Even so. Amen.",
+							"verse": 33
+						}
+					]
+				},
+				{
+					"chapter": 47,
+					"reference": "D&C 47",
+					"verses": [{
+							"reference": "D&C 47:1",
+							"text": "Behold, it is expedient in me that my servant John should write and keep a regular history, and assist you, my servant Joseph, in transcribing all things which shall be given you, until he is called to further duties.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 47:2",
+							"text": "Again, verily I say unto you that he can also lift up his voice in meetings, whenever it shall be expedient.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 47:3",
+							"text": "And again, I say unto you that it shall be appointed unto him to keep the church record and history continually; for Oliver Cowdery I have appointed to another office.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 47:4",
+							"text": "Wherefore, it shall be given him, inasmuch as he is faithful, by the Comforter, to write these things. Even so. Amen.",
+							"verse": 4
+						}
+					]
+				},
+				{
+					"chapter": 48,
+					"reference": "D&C 48",
+					"verses": [{
+							"reference": "D&C 48:1",
+							"text": "It is necessary that ye should remain for the present time in your places of abode, as it shall be suitable to your circumstances.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 48:2",
+							"text": "And inasmuch as ye have lands, ye shall impart to the eastern brethren;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 48:3",
+							"text": "And inasmuch as ye have not lands, let them buy for the present time in those regions round about, as seemeth them good, for it must needs be necessary that they have places to live for the present time.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 48:4",
+							"text": "It must needs be necessary that ye save all the money that ye can, and that ye obtain all that ye can in righteousness, that in time ye may be enabled to purchase land for an inheritance, even the city.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 48:5",
+							"text": "The place is not yet to be revealed; but after your brethren come from the east there are to be certain men appointed, and to them it shall be given to know the place, or to them it shall be revealed.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 48:6",
+							"text": "And they shall be appointed to purchase the lands, and to make a commencement to lay the foundation of the city; and then shall ye begin to be gathered with your families, every man according to his family, according to his circumstances, and as is appointed to him by the presidency and the bishop of the church, according to the laws and commandments which ye have received, and which ye shall hereafter receive. Even so. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 49,
+					"reference": "D&C 49",
+					"verses": [{
+							"reference": "D&C 49:1",
+							"text": "Hearken unto my word, my servants Sidney, and Parley, and Leman; for behold, verily I say unto you, that I give unto you a commandment that you shall go and preach my gospel which ye have received, even as ye have received it, unto the Shakers.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 49:2",
+							"text": "Behold, I say unto you, that they desire to know the truth in part, but not all, for they are not right before me and must needs repent.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 49:3",
+							"text": "Wherefore, I send you, my servants Sidney and Parley, to preach the gospel unto them.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 49:4",
+							"text": "And my servant Leman shall be ordained unto this work, that he may reason with them, not according to that which he has received of them, but according to that which shall be taught him by you my servants; and by so doing I will bless him, otherwise he shall not prosper.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 49:5",
+							"text": "Thus saith the Lord; for I am God, and have sent mine Only Begotten Son into the world for the redemption of the world, and have decreed that he that receiveth him shall be saved, and he that receiveth him not shall be damned\u2014",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 49:6",
+							"text": "And they have done unto the Son of Man even as they listed; and he has taken his power on the right hand of his glory, and now reigneth in the heavens, and will reign till he descends on the earth to put all enemies under his feet, which time is nigh at hand\u2014",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 49:7",
+							"text": "I, the Lord God, have spoken it; but the hour and the day no man knoweth, neither the angels in heaven, nor shall they know until he comes.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 49:8",
+							"text": "Wherefore, I will that all men shall repent, for all are under sin, except those which I have reserved unto myself, holy men that ye know not of.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 49:9",
+							"text": "Wherefore, I say unto you that I have sent unto you mine everlasting covenant, even that which was from the beginning.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 49:10",
+							"text": "And that which I have promised I have so fulfilled, and the nations of the earth shall bow to it; and, if not of themselves, they shall come down, for that which is now exalted of itself shall be laid low of power.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 49:11",
+							"text": "Wherefore, I give unto you a commandment that ye go among this people, and say unto them, like unto mine apostle of old, whose name was Peter:",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 49:12",
+							"text": "Believe on the name of the Lord Jesus, who was on the earth, and is to come, the beginning and the end;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 49:13",
+							"text": "Repent and be baptized in the name of Jesus Christ, according to the holy commandment, for the remission of sins;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 49:14",
+							"text": "And whoso doeth this shall receive the gift of the Holy Ghost, by the laying on of the hands of the elders of the church.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 49:15",
+							"text": "And again, verily I say unto you, that whoso forbiddeth to marry is not ordained of God, for marriage is ordained of God unto man.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 49:16",
+							"text": "Wherefore, it is lawful that he should have one wife, and they twain shall be one flesh, and all this that the earth might answer the end of its creation;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 49:17",
+							"text": "And that it might be filled with the measure of man, according to his creation before the world was made.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 49:18",
+							"text": "And whoso forbiddeth to abstain from meats, that man should not eat the same, is not ordained of God;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 49:19",
+							"text": "For, behold, the beasts of the field and the fowls of the air, and that which cometh of the earth, is ordained for the use of man for food and for raiment, and that he might have in abundance.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 49:20",
+							"text": "But it is not given that one man should possess that which is above another, wherefore the world lieth in sin.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 49:21",
+							"text": "And wo be unto man that sheddeth blood or that wasteth flesh and hath no need.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 49:22",
+							"text": "And again, verily I say unto you, that the Son of Man cometh not in the form of a woman, neither of a man traveling on the earth.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 49:23",
+							"text": "Wherefore, be not deceived, but continue in steadfastness, looking forth for the heavens to be shaken, and the earth to tremble and to reel to and fro as a drunken man, and for the valleys to be exalted, and for the mountains to be made low, and for the rough places to become smooth\u2014and all this when the angel shall sound his trumpet.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 49:24",
+							"text": "But before the great day of the Lord shall come, Jacob shall flourish in the wilderness, and the Lamanites shall blossom as the rose.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 49:25",
+							"text": "Zion shall flourish upon the hills and rejoice upon the mountains, and shall be assembled together unto the place which I have appointed.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 49:26",
+							"text": "Behold, I say unto you, go forth as I have commanded you; repent of all your sins; ask and ye shall receive; knock and it shall be opened unto you.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 49:27",
+							"text": "Behold, I will go before you and be your rearward; and I will be in your midst, and you shall not be confounded.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 49:28",
+							"text": "Behold, I am Jesus Christ, and I come quickly. Even so. Amen.",
+							"verse": 28
+						}
+					]
+				},
+				{
+					"chapter": 50,
+					"reference": "D&C 50",
+					"verses": [{
+							"reference": "D&C 50:1",
+							"text": "Hearken, O ye elders of my church, and give ear to the voice of the living God; and attend to the words of wisdom which shall be given unto you, according as ye have asked and are agreed as touching the church, and the spirits which have gone abroad in the earth.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 50:2",
+							"text": "Behold, verily I say unto you, that there are many spirits which are false spirits, which have gone forth in the earth, deceiving the world.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 50:3",
+							"text": "And also Satan hath sought to deceive you, that he might overthrow you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 50:4",
+							"text": "Behold, I, the Lord, have looked upon you, and have seen abominations in the church that profess my name.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 50:5",
+							"text": "But blessed are they who are faithful and endure, whether in life or in death, for they shall inherit eternal life.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 50:6",
+							"text": "But wo unto them that are deceivers and hypocrites, for, thus saith the Lord, I will bring them to judgment.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 50:7",
+							"text": "Behold, verily I say unto you, there are hypocrites among you, who have deceived some, which has given the adversary power; but behold such shall be reclaimed;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 50:8",
+							"text": "But the hypocrites shall be detected and shall be cut off, either in life or in death, even as I will; and wo unto them who are cut off from my church, for the same are overcome of the world.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 50:9",
+							"text": "Wherefore, let every man beware lest he do that which is not in truth and righteousness before me.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 50:10",
+							"text": "And now come, saith the Lord, by the Spirit, unto the elders of his church, and let us reason together, that ye may understand;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 50:11",
+							"text": "Let us reason even as a man reasoneth one with another face to face.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 50:12",
+							"text": "Now, when a man reasoneth he is understood of man, because he reasoneth as a man; even so will I, the Lord, reason with you that you may understand.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 50:13",
+							"text": "Wherefore, I the Lord ask you this question\u2014unto what were ye ordained?",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 50:14",
+							"text": "To preach my gospel by the Spirit, even the Comforter which was sent forth to teach the truth.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 50:15",
+							"text": "And then received ye spirits which ye could not understand, and received them to be of God; and in this are ye justified?",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 50:16",
+							"text": "Behold ye shall answer this question yourselves; nevertheless, I will be merciful unto you; he that is weak among you hereafter shall be made strong.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 50:17",
+							"text": "Verily I say unto you, he that is ordained of me and sent forth to preach the word of truth by the Comforter, in the Spirit of truth, doth he preach it by the Spirit of truth or some other way?",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 50:18",
+							"text": "And if it be by some other way it is not of God.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 50:19",
+							"text": "And again, he that receiveth the word of truth, doth he receive it by the Spirit of truth or some other way?",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 50:20",
+							"text": "If it be some other way it is not of God.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 50:21",
+							"text": "Therefore, why is it that ye cannot understand and know, that he that receiveth the word by the Spirit of truth receiveth it as it is preached by the Spirit of truth?",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 50:22",
+							"text": "Wherefore, he that preacheth and he that receiveth, understand one another, and both are edified and rejoice together.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 50:23",
+							"text": "And that which doth not edify is not of God, and is darkness.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 50:24",
+							"text": "That which is of God is light; and he that receiveth light, and continueth in God, receiveth more light; and that light groweth brighter and brighter until the perfect day.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 50:25",
+							"text": "And again, verily I say unto you, and I say it that you may know the truth, that you may chase darkness from among you;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 50:26",
+							"text": "He that is ordained of God and sent forth, the same is appointed to be the greatest, notwithstanding he is the least and the servant of all.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 50:27",
+							"text": "Wherefore, he is possessor of all things; for all things are subject unto him, both in heaven and on the earth, the life and the light, the Spirit and the power, sent forth by the will of the Father through Jesus Christ, his Son.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 50:28",
+							"text": "But no man is possessor of all things except he be purified and cleansed from all sin.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 50:29",
+							"text": "And if ye are purified and cleansed from all sin, ye shall ask whatsoever you will in the name of Jesus and it shall be done.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 50:30",
+							"text": "But know this, it shall be given you what you shall ask; and as ye are appointed to the head, the spirits shall be subject unto you.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 50:31",
+							"text": "Wherefore, it shall come to pass, that if you behold a spirit manifested that you cannot understand, and you receive not that spirit, ye shall ask of the Father in the name of Jesus; and if he give not unto you that spirit, then you may know that it is not of God.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 50:32",
+							"text": "And it shall be given unto you, power over that spirit; and you shall proclaim against that spirit with a loud voice that it is not of God\u2014",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 50:33",
+							"text": "Not with railing accusation, that ye be not overcome, neither with boasting nor rejoicing, lest you be seized therewith.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 50:34",
+							"text": "He that receiveth of God, let him account it of God; and let him rejoice that he is accounted of God worthy to receive.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 50:35",
+							"text": "And by giving heed and doing these things which ye have received, and which ye shall hereafter receive\u2014and the kingdom is given you of the Father, and power to overcome all things which are not ordained of him\u2014",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 50:36",
+							"text": "And behold, verily I say unto you, blessed are you who are now hearing these words of mine from the mouth of my servant, for your sins are forgiven you.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 50:37",
+							"text": "Let my servant Joseph Wakefield, in whom I am well pleased, and my servant Parley P. Pratt go forth among the churches and strengthen them by the word of exhortation;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 50:38",
+							"text": "And also my servant John Corrill, or as many of my servants as are ordained unto this office, and let them labor in the vineyard; and let no man hinder them doing that which I have appointed unto them\u2014",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 50:39",
+							"text": "Wherefore, in this thing my servant Edward Partridge is not justified; nevertheless let him repent and he shall be forgiven.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 50:40",
+							"text": "Behold, ye are little children and ye cannot bear all things now; ye must grow in grace and in the knowledge of the truth.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 50:41",
+							"text": "Fear not, little children, for you are mine, and I have overcome the world, and you are of them that my Father hath given me;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 50:42",
+							"text": "And none of them that my Father hath given me shall be lost.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 50:43",
+							"text": "And the Father and I are one. I am in the Father and the Father in me; and inasmuch as ye have received me, ye are in me and I in you.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 50:44",
+							"text": "Wherefore, I am in your midst, and I am the good shepherd, and the stone of Israel. He that buildeth upon this rock shall never fall.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 50:45",
+							"text": "And the day cometh that you shall hear my voice and see me, and know that I am.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 50:46",
+							"text": "Watch, therefore, that ye may be ready. Even so. Amen.",
+							"verse": 46
+						}
+					]
+				}
+			]
+		},
+		{
+			"book": "D&C 51-75",
+			"chapters": [{
+					"chapter": 51,
+					"reference": "D&C 51",
+					"verses": [{
+							"reference": "D&C 51:1",
+							"text": "Hearken unto me, saith the Lord your God, and I will speak unto my servant Edward Partridge, and give unto him directions; for it must needs be that he receive directions how to organize this people.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 51:2",
+							"text": "For it must needs be that they be organized according to my laws; if otherwise, they will be cut off.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 51:3",
+							"text": "Wherefore, let my servant Edward Partridge, and those whom he has chosen, in whom I am well pleased, appoint unto this people their portions, every man equal according to his family, according to his circumstances and his wants and needs.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 51:4",
+							"text": "And let my servant Edward Partridge, when he shall appoint a man his portion, give unto him a writing that shall secure unto him his portion, that he shall hold it, even this right and this inheritance in the church, until he transgresses and is not accounted worthy by the voice of the church, according to the laws and covenants of the church, to belong to the church.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 51:5",
+							"text": "And if he shall transgress and is not accounted worthy to belong to the church, he shall not have power to claim that portion which he has consecrated unto the bishop for the poor and needy of my church; therefore, he shall not retain the gift, but shall only have claim on that portion that is deeded unto him.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 51:6",
+							"text": "And thus all things shall be made sure, according to the laws of the land.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 51:7",
+							"text": "And let that which belongs to this people be appointed unto this people.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 51:8",
+							"text": "And the money which is left unto this people\u2014let there be an agent appointed unto this people, to take the money to provide food and raiment, according to the wants of this people.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 51:9",
+							"text": "And let every man deal honestly, and be alike among this people, and receive alike, that ye may be one, even as I have commanded you.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 51:10",
+							"text": "And let that which belongeth to this people not be taken and given unto that of another church.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 51:11",
+							"text": "Wherefore, if another church would receive money of this church, let them pay unto this church again according as they shall agree;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 51:12",
+							"text": "And this shall be done through the bishop or the agent, which shall be appointed by the voice of the church.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 51:13",
+							"text": "And again, let the bishop appoint a storehouse unto this church; and let all things both in money and in meat, which are more than is needful for the wants of this people, be kept in the hands of the bishop.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 51:14",
+							"text": "And let him also reserve unto himself for his own wants, and for the wants of his family, as he shall be employed in doing this business.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 51:15",
+							"text": "And thus I grant unto this people a privilege of organizing themselves according to my laws.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 51:16",
+							"text": "And I consecrate unto them this land for a little season, until I, the Lord, shall provide for them otherwise, and command them to go hence;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 51:17",
+							"text": "And the hour and the day is not given unto them, wherefore let them act upon this land as for years, and this shall turn unto them for their good.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 51:18",
+							"text": "Behold, this shall be an example unto my servant Edward Partridge, in other places, in all churches.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 51:19",
+							"text": "And whoso is found a faithful, a just, and a wise steward shall enter into the joy of his Lord, and shall inherit eternal life.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 51:20",
+							"text": "Verily, I say unto you, I am Jesus Christ, who cometh quickly, in an hour you think not. Even so. Amen.",
+							"verse": 20
+						}
+					]
+				},
+				{
+					"chapter": 52,
+					"reference": "D&C 52",
+					"verses": [{
+							"reference": "D&C 52:1",
+							"text": "Behold, thus saith the Lord unto the elders whom he hath called and chosen in these last days, by the voice of his Spirit\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 52:2",
+							"text": "Saying: I, the Lord, will make known unto you what I will that ye shall do from this time until the next conference, which shall be held in Missouri, upon the land which I will consecrate unto my people, which are a remnant of Jacob, and those who are heirs according to the covenant.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 52:3",
+							"text": "Wherefore, verily I say unto you, let my servants Joseph Smith, Jun., and Sidney Rigdon take their journey as soon as preparations can be made to leave their homes, and journey to the land of Missouri.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 52:4",
+							"text": "And inasmuch as they are faithful unto me, it shall be made known unto them what they shall do;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 52:5",
+							"text": "And it shall also, inasmuch as they are faithful, be made known unto them the land of your inheritance.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 52:6",
+							"text": "And inasmuch as they are not faithful, they shall be cut off, even as I will, as seemeth me good.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 52:7",
+							"text": "And again, verily I say unto you, let my servant Lyman Wight and my servant John Corrill take their journey speedily;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 52:8",
+							"text": "And also my servant John Murdock, and my servant Hyrum Smith, take their journey unto the same place by the way of Detroit.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 52:9",
+							"text": "And let them journey from thence preaching the word by the way, saying none other things than that which the prophets and apostles have written, and that which is taught them by the Comforter through the prayer of faith.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 52:10",
+							"text": "Let them go two by two, and thus let them preach by the way in every congregation, baptizing by water, and the laying on of the hands by the water's side.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 52:11",
+							"text": "For thus saith the Lord, I will cut my work short in righteousness, for the days come that I will send forth judgment unto victory.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 52:12",
+							"text": "And let my servant Lyman Wight beware, for Satan desireth to sift him as chaff.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 52:13",
+							"text": "And behold, he that is faithful shall be made ruler over many things.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 52:14",
+							"text": "And again, I will give unto you a pattern in all things, that ye may not be deceived; for Satan is abroad in the land, and he goeth forth deceiving the nations\u2014",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 52:15",
+							"text": "Wherefore he that prayeth, whose spirit is contrite, the same is accepted of me if he obey mine ordinances.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 52:16",
+							"text": "He that speaketh, whose spirit is contrite, whose language is meek and edifieth, the same is of God if he obey mine ordinances.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 52:17",
+							"text": "And again, he that trembleth under my power shall be made strong, and shall bring forth fruits of praise and wisdom, according to the revelations and truths which I have given you.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 52:18",
+							"text": "And again, he that is overcome and bringeth not forth fruits, even according to this pattern, is not of me.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 52:19",
+							"text": "Wherefore, by this pattern ye shall know the spirits in all cases under the whole heavens.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 52:20",
+							"text": "And the days have come; according to men's faith it shall be done unto them.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 52:21",
+							"text": "Behold, this commandment is given unto all the elders whom I have chosen.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 52:22",
+							"text": "And again, verily I say unto you, let my servant Thomas B. Marsh and my servant Ezra Thayre take their journey also, preaching the word by the way unto this same land.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 52:23",
+							"text": "And again, let my servant Isaac Morley and my servant Ezra Booth take their journey, also preaching the word by the way unto this same land.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 52:24",
+							"text": "And again, let my servants Edward Partridge and Martin Harris take their journey with my servants Sidney Rigdon and Joseph Smith, Jun.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 52:25",
+							"text": "Let my servants David Whitmer and Harvey Whitlock also take their journey, and preach by the way unto this same land.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 52:26",
+							"text": "And let my servants Parley P. Pratt and Orson Pratt take their journey, and preach by the way, even unto this same land.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 52:27",
+							"text": "And let my servants Solomon Hancock and Simeon Carter also take their journey unto this same land, and preach by the way.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 52:28",
+							"text": "Let my servants Edson Fuller and Jacob Scott also take their journey.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 52:29",
+							"text": "Let my servants Levi W. Hancock and Zebedee Coltrin also take their journey.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 52:30",
+							"text": "Let my servants Reynolds Cahoon and Samuel H. Smith also take their journey.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 52:31",
+							"text": "Let my servants Wheeler Baldwin and William Carter also take their journey.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 52:32",
+							"text": "And let my servants Newel Knight and Selah J. Griffin both be ordained, and also take their journey.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 52:33",
+							"text": "Yea, verily I say, let all these take their journey unto one place, in their several courses, and one man shall not build upon another's foundation, neither journey in another's track.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 52:34",
+							"text": "He that is faithful, the same shall be kept and blessed with much fruit.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 52:35",
+							"text": "And again, I say unto you, let my servants Joseph Wakefield and Solomon Humphrey take their journey into the eastern lands;",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 52:36",
+							"text": "Let them labor with their families, declaring none other things than the prophets and apostles, that which they have seen and heard and most assuredly believe, that the prophecies may be fulfilled.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 52:37",
+							"text": "In consequence of transgression, let that which was bestowed upon Heman Basset be taken from him, and placed upon the head of Simonds Ryder.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 52:38",
+							"text": "And again, verily I say unto you, let Jared Carter be ordained a priest, and also George James be ordained a priest.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 52:39",
+							"text": "Let the residue of the elders watch over the churches, and declare the word in the regions round about them; and let them labor with their own hands that there be no idolatry nor wickedness practiced.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 52:40",
+							"text": "And remember in all things the poor and the needy, the sick and the afflicted, for he that doeth not these things, the same is not my disciple.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 52:41",
+							"text": "And again, let my servants Joseph Smith, Jun., and Sidney Rigdon and Edward Partridge take with them a recommend from the church. And let there be one obtained for my servant Oliver Cowdery also.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 52:42",
+							"text": "And thus, even as I have said, if ye are faithful ye shall assemble yourselves together to rejoice upon the land of Missouri, which is the land of your inheritance, which is now the land of your enemies.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 52:43",
+							"text": "But, behold, I, the Lord, will hasten the city in its time, and will crown the faithful with joy and with rejoicing.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 52:44",
+							"text": "Behold, I am Jesus Christ, the Son of God, and I will lift them up at the last day. Even so. Amen.",
+							"verse": 44
+						}
+					]
+				},
+				{
+					"chapter": 53,
+					"reference": "D&C 53",
+					"verses": [{
+							"reference": "D&C 53:1",
+							"text": "Behold, I say unto you, my servant Sidney Gilbert, that I have heard your prayers; and you have called upon me that it should be made known unto you, of the Lord your God, concerning your calling and election in the church, which I, the Lord, have raised up in these last days.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 53:2",
+							"text": "Behold, I, the Lord, who was crucified for the sins of the world, give unto you a commandment that you shall forsake the world.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 53:3",
+							"text": "Take upon you mine ordination, even that of an elder, to preach faith and repentance and remission of sins, according to my word, and the reception of the Holy Spirit by the laying on of hands;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 53:4",
+							"text": "And also to be an agent unto this church in the place which shall be appointed by the bishop, according to commandments which shall be given hereafter.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 53:5",
+							"text": "And again, verily I say unto you, you shall take your journey with my servants Joseph Smith, Jun., and Sidney Rigdon.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 53:6",
+							"text": "Behold, these are the first ordinances which you shall receive; and the residue shall be made known in a time to come, according to your labor in my vineyard.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 53:7",
+							"text": "And again, I would that ye should learn that he only is saved who endureth unto the end. Even so. Amen.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 54,
+					"reference": "D&C 54",
+					"verses": [{
+							"reference": "D&C 54:1",
+							"text": "Behold, thus saith the Lord, even Alpha and Omega, the beginning and the end, even he who was crucified for the sins of the world\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 54:2",
+							"text": "Behold, verily, verily, I say unto you, my servant Newel Knight, you shall stand fast in the office whereunto I have appointed you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 54:3",
+							"text": "And if your brethren desire to escape their enemies, let them repent of all their sins, and become truly humble before me and contrite.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 54:4",
+							"text": "And as the covenant which they made unto me has been broken, even so it has become void and of none effect.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 54:5",
+							"text": "And wo to him by whom this offense cometh, for it had been better for him that he had been drowned in the depth of the sea.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 54:6",
+							"text": "But blessed are they who have kept the covenant and observed the commandment, for they shall obtain mercy.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 54:7",
+							"text": "Wherefore, go to now and flee the land, lest your enemies come upon you; and take your journey, and appoint whom you will to be your leader, and to pay moneys for you.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 54:8",
+							"text": "And thus you shall take your journey into the regions westward, unto the land of Missouri, unto the borders of the Lamanites.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 54:9",
+							"text": "And after you have done journeying, behold, I say unto you, seek ye a living like unto men, until I prepare a place for you.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 54:10",
+							"text": "And again, be patient in tribulation until I come; and, behold, I come quickly, and my reward is with me, and they who have sought me early shall find rest to their souls. Even so. Amen.",
+							"verse": 10
+						}
+					]
+				},
+				{
+					"chapter": 55,
+					"reference": "D&C 55",
+					"verses": [{
+							"reference": "D&C 55:1",
+							"text": "Behold, thus saith the Lord unto you, my servant William, yea, even the Lord of the whole earth, thou art called and chosen; and after thou hast been baptized by water, which if you do with an eye single to my glory, you shall have a remission of your sins and a reception of the Holy Spirit by the laying on of hands;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 55:2",
+							"text": "And then thou shalt be ordained by the hand of my servant Joseph Smith, Jun., to be an elder unto this church, to preach repentance and remission of sins by way of baptism in the name of Jesus Christ, the Son of the living God.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 55:3",
+							"text": "And on whomsoever you shall lay your hands, if they are contrite before me, you shall have power to give the Holy Spirit.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 55:4",
+							"text": "And again, you shall be ordained to assist my servant Oliver Cowdery to do the work of printing, and of selecting and writing books for schools in this church, that little children also may receive instruction before me as is pleasing unto me.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 55:5",
+							"text": "And again, verily I say unto you, for this cause you shall take your journey with my servants Joseph Smith, Jun., and Sidney Rigdon, that you may be planted in the land of your inheritance to do this work.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 55:6",
+							"text": "And again, let my servant Joseph Coe also take his journey with them. The residue shall be made known hereafter, even as I will. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 56,
+					"reference": "D&C 56",
+					"verses": [{
+							"reference": "D&C 56:1",
+							"text": "Hearken, O ye people who profess my name, saith the Lord your God; for behold, mine anger is kindled against the rebellious, and they shall know mine arm and mine indignation, in the day of visitation and of wrath upon the nations.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 56:2",
+							"text": "And he that will not take up his cross and follow me, and keep my commandments, the same shall not be saved.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 56:3",
+							"text": "Behold, I, the Lord, command; and he that will not obey shall be cut off in mine own due time, after I have commanded and the commandment is broken.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 56:4",
+							"text": "Wherefore I, the Lord, command and revoke, as it seemeth me good; and all this to be answered upon the heads of the rebellious, saith the Lord.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 56:5",
+							"text": "Wherefore, I revoke the commandment which was given unto my servants Thomas B. Marsh and Ezra Thayre, and give a new commandment unto my servant Thomas, that he shall take up his journey speedily to the land of Missouri, and my servant Selah J. Griffin shall also go with him.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 56:6",
+							"text": "For behold, I revoke the commandment which was given unto my servants Selah J. Griffin and Newel Knight, in consequence of the stiffneckedness of my people which are in Thompson, and their rebellions.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 56:7",
+							"text": "Wherefore, let my servant Newel Knight remain with them; and as many as will go may go, that are contrite before me, and be led by him to the land which I have appointed.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 56:8",
+							"text": "And again, verily I say unto you, that my servant Ezra Thayre must repent of his pride, and of his selfishness, and obey the former commandment which I have given him concerning the place upon which he lives.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 56:9",
+							"text": "And if he will do this, as there shall be no divisions made upon the land, he shall be appointed still to go to the land of Missouri;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 56:10",
+							"text": "Otherwise he shall receive the money which he has paid, and shall leave the place, and shall be cut off out of my church, saith the Lord God of hosts;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 56:11",
+							"text": "And though the heaven and the earth pass away, these words shall not pass away, but shall be fulfilled.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 56:12",
+							"text": "And if my servant Joseph Smith, Jun., must needs pay the money, behold, I, the Lord, will pay it unto him again in the land of Missouri, that those of whom he shall receive may be rewarded again according to that which they do;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 56:13",
+							"text": "For according to that which they do they shall receive, even in lands for their inheritance.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 56:14",
+							"text": "Behold, thus saith the Lord unto my people\u2014you have many things to do and to repent of; for behold, your sins have come up unto me, and are not pardoned, because you seek to counsel in your own ways.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 56:15",
+							"text": "And your hearts are not satisfied. And ye obey not the truth, but have pleasure in unrighteousness.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 56:16",
+							"text": "Wo unto you rich men, that will not give your substance to the poor, for your riches will canker your souls; and this shall be your lamentation in the day of visitation, and of judgment, and of indignation: The harvest is past, the summer is ended, and my soul is not saved!",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 56:17",
+							"text": "Wo unto you poor men, whose hearts are not broken, whose spirits are not contrite, and whose bellies are not satisfied, and whose hands are not stayed from laying hold upon other men's goods, whose eyes are full of greediness, and who will not labor with your own hands!",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 56:18",
+							"text": "But blessed are the poor who are pure in heart, whose hearts are broken, and whose spirits are contrite, for they shall see the kingdom of God coming in power and great glory unto their deliverance; for the fatness of the earth shall be theirs.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 56:19",
+							"text": "For behold, the Lord shall come, and his recompense shall be with him, and he shall reward every man, and the poor shall rejoice;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 56:20",
+							"text": "And their generations shall inherit the earth from generation to generation, forever and ever. And now I make an end of speaking unto you. Even so. Amen.",
+							"verse": 20
+						}
+					]
+				},
+				{
+					"chapter": 57,
+					"reference": "D&C 57",
+					"verses": [{
+							"reference": "D&C 57:1",
+							"text": "Hearken, O ye elders of my church, saith the Lord your God, who have assembled yourselves together, according to my commandments, in this land, which is the land of Missouri, which is the land which I have appointed and consecrated for the gathering of the saints.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 57:2",
+							"text": "Wherefore, this is the land of promise, and the place for the city of Zion.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 57:3",
+							"text": "And thus saith the Lord your God, if you will receive wisdom here is wisdom. Behold, the place which is now called Independence is the center place; and a spot for the temple is lying westward, upon a lot which is not far from the courthouse.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 57:4",
+							"text": "Wherefore, it is wisdom that the land should be purchased by the saints, and also every tract lying westward, even unto the line running directly between Jew and Gentile;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 57:5",
+							"text": "And also every tract bordering by the prairies, inasmuch as my disciples are enabled to buy lands. Behold, this is wisdom, that they may obtain it for an everlasting inheritance.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 57:6",
+							"text": "And let my servant Sidney Gilbert stand in the office to which I have appointed him, to receive moneys, to be an agent unto the church, to buy land in all the regions round about, inasmuch as can be done in righteousness, and as wisdom shall direct.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 57:7",
+							"text": "And let my servant Edward Partridge stand in the office to which I have appointed him, and divide unto the saints their inheritance, even as I have commanded; and also those whom he has appointed to assist him.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 57:8",
+							"text": "And again, verily I say unto you, let my servant Sidney Gilbert plant himself in this place, and establish a store, that he may sell goods without fraud, that he may obtain money to buy lands for the good of the saints, and that he may obtain whatsoever things the disciples may need to plant them in their inheritance.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 57:9",
+							"text": "And also let my servant Sidney Gilbert obtain a license\u2014behold here is wisdom, and whoso readeth let him understand\u2014that he may send goods also unto the people, even by whom he will as clerks employed in his service;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 57:10",
+							"text": "And thus provide for my saints, that my gospel may be preached unto those who sit in darkness and in the region and shadow of death.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 57:11",
+							"text": "And again, verily I say unto you, let my servant William W. Phelps be planted in this place, and be established as a printer unto the church.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 57:12",
+							"text": "And lo, if the world receive his writings\u2014behold here is wisdom\u2014let him obtain whatsoever he can obtain in righteousness, for the good of the saints.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 57:13",
+							"text": "And let my servant Oliver Cowdery assist him, even as I have commanded, in whatsoever place I shall appoint unto him, to copy, and to correct, and select, that all things may be right before me, as it shall be proved by the Spirit through him.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 57:14",
+							"text": "And thus let those of whom I have spoken be planted in the land of Zion, as speedily as can be, with their families, to do those things even as I have spoken.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 57:15",
+							"text": "And now concerning the gathering\u2014Let the bishop and the agent make preparations for those families which have been commanded to come to this land, as soon as possible, and plant them in their inheritance.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 57:16",
+							"text": "And unto the residue of both elders and members further directions shall be given hereafter. Even so. Amen.",
+							"verse": 16
+						}
+					]
+				},
+				{
+					"chapter": 58,
+					"reference": "D&C 58",
+					"verses": [{
+							"reference": "D&C 58:1",
+							"text": "Hearken, O ye elders of my church, and give ear to my word, and learn of me what I will concerning you, and also concerning this land unto which I have sent you.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 58:2",
+							"text": "For verily I say unto you, blessed is he that keepeth my commandments, whether in life or in death; and he that is faithful in tribulation, the reward of the same is greater in the kingdom of heaven.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 58:3",
+							"text": "Ye cannot behold with your natural eyes, for the present time, the design of your God concerning those things which shall come hereafter, and the glory which shall follow after much tribulation.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 58:4",
+							"text": "For after much tribulation come the blessings. Wherefore the day cometh that ye shall be crowned with much glory; the hour is not yet, but is nigh at hand.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 58:5",
+							"text": "Remember this, which I tell you before, that you may lay it to heart, and receive that which is to follow.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 58:6",
+							"text": "Behold, verily I say unto you, for this cause I have sent you\u2014that you might be obedient, and that your hearts might be prepared to bear testimony of the things which are to come;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 58:7",
+							"text": "And also that you might be honored in laying the foundation, and in bearing record of the land upon which the Zion of God shall stand;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 58:8",
+							"text": "And also that a feast of fat things might be prepared for the poor; yea, a feast of fat things, of wine on the lees well refined, that the earth may know that the mouths of the prophets shall not fail;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 58:9",
+							"text": "Yea, a supper of the house of the Lord, well prepared, unto which all nations shall be invited.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 58:10",
+							"text": "First, the rich and the learned, the wise and the noble;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 58:11",
+							"text": "And after that cometh the day of my power; then shall the poor, the lame, and the blind, and the deaf, come in unto the marriage of the Lamb, and partake of the supper of the Lord, prepared for the great day to come.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 58:12",
+							"text": "Behold, I, the Lord, have spoken it.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 58:13",
+							"text": "And that the testimony might go forth from Zion, yea, from the mouth of the city of the heritage of God\u2014",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 58:14",
+							"text": "Yea, for this cause I have sent you hither, and have selected my servant Edward Partridge, and have appointed unto him his mission in this land.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 58:15",
+							"text": "But if he repent not of his sins, which are unbelief and blindness of heart, let him take heed lest he fall.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 58:16",
+							"text": "Behold his mission is given unto him, and it shall not be given again.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 58:17",
+							"text": "And whoso standeth in this mission is appointed to be a judge in Israel, like as it was in ancient days, to divide the lands of the heritage of God unto his children;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 58:18",
+							"text": "And to judge his people by the testimony of the just, and by the assistance of his counselors, according to the laws of the kingdom which are given by the prophets of God.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 58:19",
+							"text": "For verily I say unto you, my law shall be kept on this land.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 58:20",
+							"text": "Let no man think he is ruler; but let God rule him that judgeth, according to the counsel of his own will, or, in other words, him that counseleth or sitteth upon the judgment seat.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 58:21",
+							"text": "Let no man break the laws of the land, for he that keepeth the laws of God hath no need to break the laws of the land.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 58:22",
+							"text": "Wherefore, be subject to the powers that be, until he reigns whose right it is to reign, and subdues all enemies under his feet.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 58:23",
+							"text": "Behold, the laws which ye have received from my hand are the laws of the church, and in this light ye shall hold them forth. Behold, here is wisdom.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 58:24",
+							"text": "And now, as I spake concerning my servant Edward Partridge, this land is the land of his residence, and those whom he has appointed for his counselors; and also the land of the residence of him whom I have appointed to keep my storehouse;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 58:25",
+							"text": "Wherefore, let them bring their families to this land, as they shall counsel between themselves and me.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 58:26",
+							"text": "For behold, it is not meet that I should command in all things; for he that is compelled in all things, the same is a slothful and not a wise servant; wherefore he receiveth no reward.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 58:27",
+							"text": "Verily I say, men should be anxiously engaged in a good cause, and do many things of their own free will, and bring to pass much righteousness;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 58:28",
+							"text": "For the power is in them, wherein they are agents unto themselves. And inasmuch as men do good they shall in nowise lose their reward.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 58:29",
+							"text": "But he that doeth not anything until he is commanded, and receiveth a commandment with doubtful heart, and keepeth it with slothfulness, the same is damned.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 58:30",
+							"text": "Who am I that made man, saith the Lord, that will hold him guiltless that obeys not my commandments?",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 58:31",
+							"text": "Who am I, saith the Lord, that have promised and have not fulfilled?",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 58:32",
+							"text": "I command and men obey not; I revoke and they receive not the blessing.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 58:33",
+							"text": "Then they say in their hearts: This is not the work of the Lord, for his promises are not fulfilled. But wo unto such, for their reward lurketh beneath, and not from above.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 58:34",
+							"text": "And now I give unto you further directions concerning this land.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 58:35",
+							"text": "It is wisdom in me that my servant Martin Harris should be an example unto the church, in laying his moneys before the bishop of the church.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 58:36",
+							"text": "And also, this is a law unto every man that cometh unto this land to receive an inheritance; and he shall do with his moneys according as the law directs.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 58:37",
+							"text": "And it is wisdom also that there should be lands purchased in Independence, for the place of the storehouse, and also for the house of the printing.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 58:38",
+							"text": "And other directions concerning my servant Martin Harris shall be given him of the Spirit, that he may receive his inheritance as seemeth him good;",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 58:39",
+							"text": "And let him repent of his sins, for he seeketh the praise of the world.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 58:40",
+							"text": "And also let my servant William W. Phelps stand in the office to which I have appointed him, and receive his inheritance in the land;",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 58:41",
+							"text": "And also he hath need to repent, for I, the Lord, am not well pleased with him, for he seeketh to excel, and he is not sufficiently meek before me.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 58:42",
+							"text": "Behold, he who has repented of his sins, the same is forgiven, and I, the Lord, remember them no more.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 58:43",
+							"text": "By this ye may know if a man repenteth of his sins\u2014behold, he will confess them and forsake them.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 58:44",
+							"text": "And now, verily, I say concerning the residue of the elders of my church, the time has not yet come, for many years, for them to receive their inheritance in this land, except they desire it through the prayer of faith, only as it shall be appointed unto them of the Lord.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 58:45",
+							"text": "For, behold, they shall push the people together from the ends of the earth.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 58:46",
+							"text": "Wherefore, assemble yourselves together; and they who are not appointed to stay in this land, let them preach the gospel in the regions round about; and after that let them return to their homes.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 58:47",
+							"text": "Let them preach by the way, and bear testimony of the truth in all places, and call upon the rich, the high and the low, and the poor to repent.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 58:48",
+							"text": "And let them build up churches, inasmuch as the inhabitants of the earth will repent.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 58:49",
+							"text": "And let there be an agent appointed by the voice of the church, unto the church in Ohio, to receive moneys to purchase lands in Zion.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 58:50",
+							"text": "And I give unto my servant Sidney Rigdon a commandment, that he shall write a description of the land of Zion, and a statement of the will of God, as it shall be made known by the Spirit unto him;",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 58:51",
+							"text": "And an epistle and subscription, to be presented unto all the churches to obtain moneys, to be put into the hands of the bishop, of himself or the agent, as seemeth him good or as he shall direct, to purchase lands for an inheritance for the children of God.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 58:52",
+							"text": "For, behold, verily I say unto you, the Lord willeth that the disciples and the children of men should open their hearts, even to purchase this whole region of country, as soon as time will permit.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 58:53",
+							"text": "Behold, here is wisdom. Let them do this lest they receive none inheritance, save it be by the shedding of blood.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 58:54",
+							"text": "And again, inasmuch as there is land obtained, let there be workmen sent forth of all kinds unto this land, to labor for the saints of God.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 58:55",
+							"text": "Let all these things be done in order; and let the privileges of the lands be made known from time to time, by the bishop or the agent of the church.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 58:56",
+							"text": "And let the work of the gathering be not in haste, nor by flight; but let it be done as it shall be counseled by the elders of the church at the conferences, according to the knowledge which they receive from time to time.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 58:57",
+							"text": "And let my servant Sidney Rigdon consecrate and dedicate this land, and the spot for the temple, unto the Lord.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 58:58",
+							"text": "And let a conference meeting be called; and after that let my servants Sidney Rigdon and Joseph Smith, Jun., return, and also Oliver Cowdery with them, to accomplish the residue of the work which I have appointed unto them in their own land, and the residue as shall be ruled by the conferences.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 58:59",
+							"text": "And let no man return from this land except he bear record by the way, of that which he knows and most assuredly believes.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 58:60",
+							"text": "Let that which has been bestowed upon Ziba Peterson be taken from him; and let him stand as a member in the church, and labor with his own hands, with the brethren, until he is sufficiently chastened for all his sins; for he confesseth them not, and he thinketh to hide them.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 58:61",
+							"text": "Let the residue of the elders of this church, who are coming to this land, some of whom are exceedingly blessed even above measure, also hold a conference upon this land.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 58:62",
+							"text": "And let my servant Edward Partridge direct the conference which shall be held by them.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 58:63",
+							"text": "And let them also return, preaching the gospel by the way, bearing record of the things which are revealed unto them.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 58:64",
+							"text": "For, verily, the sound must go forth from this place into all the world, and unto the uttermost parts of the earth\u2014the gospel must be preached unto every creature, with signs following them that believe.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 58:65",
+							"text": "And behold the Son of Man cometh. Amen.",
+							"verse": 65
+						}
+					]
+				},
+				{
+					"chapter": 59,
+					"reference": "D&C 59",
+					"verses": [{
+							"reference": "D&C 59:1",
+							"text": "Behold, blessed, saith the Lord, are they who have come up unto this land with an eye single to my glory, according to my commandments.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 59:2",
+							"text": "For those that live shall inherit the earth, and those that die shall rest from all their labors, and their works shall follow them; and they shall receive a crown in the mansions of my Father, which I have prepared for them.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 59:3",
+							"text": "Yea, blessed are they whose feet stand upon the land of Zion, who have obeyed my gospel; for they shall receive for their reward the good things of the earth, and it shall bring forth in its strength.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 59:4",
+							"text": "And they shall also be crowned with blessings from above, yea, and with commandments not a few, and with revelations in their time\u2014they that are faithful and diligent before me.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 59:5",
+							"text": "Wherefore, I give unto them a commandment, saying thus: Thou shalt love the Lord thy God with all thy heart, with all thy might, mind, and strength; and in the name of Jesus Christ thou shalt serve him.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 59:6",
+							"text": "Thou shalt love thy neighbor as thyself. Thou shalt not steal; neither commit adultery, nor kill, nor do anything like unto it.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 59:7",
+							"text": "Thou shalt thank the Lord thy God in all things.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 59:8",
+							"text": "Thou shalt offer a sacrifice unto the Lord thy God in righteousness, even that of a broken heart and a contrite spirit.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 59:9",
+							"text": "And that thou mayest more fully keep thyself unspotted from the world, thou shalt go to the house of prayer and offer up thy sacraments upon my holy day;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 59:10",
+							"text": "For verily this is a day appointed unto you to rest from your labors, and to pay thy devotions unto the Most High;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 59:11",
+							"text": "Nevertheless thy vows shall be offered up in righteousness on all days and at all times;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 59:12",
+							"text": "But remember that on this, the Lord's day, thou shalt offer thine oblations and thy sacraments unto the Most High, confessing thy sins unto thy brethren, and before the Lord.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 59:13",
+							"text": "And on this day thou shalt do none other thing, only let thy food be prepared with singleness of heart that thy fasting may be perfect, or, in other words, that thy joy may be full.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 59:14",
+							"text": "Verily, this is fasting and prayer, or in other words, rejoicing and prayer.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 59:15",
+							"text": "And inasmuch as ye do these things with thanksgiving, with cheerful hearts and countenances, not with much laughter, for this is sin, but with a glad heart and a cheerful countenance\u2014",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 59:16",
+							"text": "Verily I say, that inasmuch as ye do this, the fulness of the earth is yours, the beasts of the field and the fowls of the air, and that which climbeth upon the trees and walketh upon the earth;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 59:17",
+							"text": "Yea, and the herb, and the good things which come of the earth, whether for food or for raiment, or for houses, or for barns, or for orchards, or for gardens, or for vineyards;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 59:18",
+							"text": "Yea, all things which come of the earth, in the season thereof, are made for the benefit and the use of man, both to please the eye and to gladden the heart;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 59:19",
+							"text": "Yea, for food and for raiment, for taste and for smell, to strengthen the body and to enliven the soul.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 59:20",
+							"text": "And it pleaseth God that he hath given all these things unto man; for unto this end were they made to be used, with judgment, not to excess, neither by extortion.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 59:21",
+							"text": "And in nothing doth man offend God, or against none is his wrath kindled, save those who confess not his hand in all things, and obey not his commandments.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 59:22",
+							"text": "Behold, this is according to the law and the prophets; wherefore, trouble me no more concerning this matter.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 59:23",
+							"text": "But learn that he who doeth the works of righteousness shall receive his reward, even peace in this world, and eternal life in the world to come.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 59:24",
+							"text": "I, the Lord, have spoken it, and the Spirit beareth record. Amen.",
+							"verse": 24
+						}
+					]
+				},
+				{
+					"chapter": 60,
+					"reference": "D&C 60",
+					"verses": [{
+							"reference": "D&C 60:1",
+							"text": "Behold, thus saith the Lord unto the elders of his church, who are to return speedily to the land from whence they came: Behold, it pleaseth me, that you have come up hither;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 60:2",
+							"text": "But with some I am not well pleased, for they will not open their mouths, but they hide the talent which I have given unto them, because of the fear of man. Wo unto such, for mine anger is kindled against them.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 60:3",
+							"text": "And it shall come to pass, if they are not more faithful unto me, it shall be taken away, even that which they have.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 60:4",
+							"text": "For I, the Lord, rule in the heavens above, and among the armies of the earth; and in the day when I shall make up my jewels, all men shall know what it is that bespeaketh the power of God.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 60:5",
+							"text": "But, verily, I will speak unto you concerning your journey unto the land from whence you came. Let there be a craft made, or bought, as seemeth you good, it mattereth not unto me, and take your journey speedily for the place which is called St. Louis.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 60:6",
+							"text": "And from thence let my servants, Sidney Rigdon, Joseph Smith, Jun., and Oliver Cowdery, take their journey for Cincinnati;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 60:7",
+							"text": "And in this place let them lift up their voice and declare my word with loud voices, without wrath or doubting, lifting up holy hands upon them. For I am able to make you holy, and your sins are forgiven you.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 60:8",
+							"text": "And let the residue take their journey from St. Louis, two by two, and preach the word, not in haste, among the congregations of the wicked, until they return to the churches from whence they came.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 60:9",
+							"text": "And all this for the good of the churches; for this intent have I sent them.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 60:10",
+							"text": "And let my servant Edward Partridge impart of the money which I have given him, a portion unto mine elders who are commanded to return;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 60:11",
+							"text": "And he that is able, let him return it by the way of the agent; and he that is not, of him it is not required.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 60:12",
+							"text": "And now I speak of the residue who are to come unto this land.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 60:13",
+							"text": "Behold, they have been sent to preach my gospel among the congregations of the wicked; wherefore, I give unto them a commandment, thus: Thou shalt not idle away thy time, neither shalt thou bury thy talent that it may not be known.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 60:14",
+							"text": "And after thou hast come up unto the land of Zion, and hast proclaimed my word, thou shalt speedily return, proclaiming my word among the congregations of the wicked, not in haste, neither in wrath nor with strife.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 60:15",
+							"text": "And shake off the dust of thy feet against those who receive thee not, not in their presence, lest thou provoke them, but in secret; and wash thy feet, as a testimony against them in the day of judgment.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 60:16",
+							"text": "Behold, this is sufficient for you, and the will of him who hath sent you.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 60:17",
+							"text": "And by the mouth of my servant Joseph Smith, Jun., it shall be made known concerning Sidney Rigdon and Oliver Cowdery. The residue hereafter. Even so. Amen.",
+							"verse": 17
+						}
+					]
+				},
+				{
+					"chapter": 61,
+					"reference": "D&C 61",
+					"verses": [{
+							"reference": "D&C 61:1",
+							"text": "Behold, and hearken unto the voice of him who has all power, who is from everlasting to everlasting, even Alpha and Omega, the beginning and the end.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 61:2",
+							"text": "Behold, verily thus saith the Lord unto you, O ye elders of my church, who are assembled upon this spot, whose sins are now forgiven you, for I, the Lord, forgive sins, and am merciful unto those who confess their sins with humble hearts;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 61:3",
+							"text": "But verily I say unto you, that it is not needful for this whole company of mine elders to be moving swiftly upon the waters, whilst the inhabitants on either side are perishing in unbelief.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 61:4",
+							"text": "Nevertheless, I suffered it that ye might bear record; behold, there are many dangers upon the waters, and more especially hereafter;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 61:5",
+							"text": "For I, the Lord, have decreed in mine anger many destructions upon the waters; yea, and especially upon these waters.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 61:6",
+							"text": "Nevertheless, all flesh is in mine hand, and he that is faithful among you shall not perish by the waters.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 61:7",
+							"text": "Wherefore, it is expedient that my servant Sidney Gilbert and my servant William W. Phelps be in haste upon their errand and mission.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 61:8",
+							"text": "Nevertheless, I would not suffer that ye should part until you were chastened for all your sins, that you might be one, that you might not perish in wickedness;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 61:9",
+							"text": "But now, verily I say, it behooveth me that ye should part. Wherefore let my servants Sidney Gilbert and William W. Phelps take their former company, and let them take their journey in haste that they may fill their mission, and through faith they shall overcome;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 61:10",
+							"text": "And inasmuch as they are faithful they shall be preserved, and I, the Lord, will be with them.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 61:11",
+							"text": "And let the residue take that which is needful for clothing.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 61:12",
+							"text": "Let my servant Sidney Gilbert take that which is not needful with him, as you shall agree.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 61:13",
+							"text": "And now, behold, for your good I gave unto you a commandment concerning these things; and I, the Lord, will reason with you as with men in days of old.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 61:14",
+							"text": "Behold, I, the Lord, in the beginning blessed the waters; but in the last days, by the mouth of my servant John, I cursed the waters.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 61:15",
+							"text": "Wherefore, the days will come that no flesh shall be safe upon the waters.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 61:16",
+							"text": "And it shall be said in days to come that none is able to go up to the land of Zion upon the waters, but he that is upright in heart.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 61:17",
+							"text": "And, as I, the Lord, in the beginning cursed the land, even so in the last days have I blessed it, in its time, for the use of my saints, that they may partake the fatness thereof.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 61:18",
+							"text": "And now I give unto you a commandment that what I say unto one I say unto all, that you shall forewarn your brethren concerning these waters, that they come not in journeying upon them, lest their faith fail and they are caught in snares;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 61:19",
+							"text": "I, the Lord, have decreed, and the destroyer rideth upon the face thereof, and I revoke not the decree.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 61:20",
+							"text": "I, the Lord, was angry with you yesterday, but today mine anger is turned away.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 61:21",
+							"text": "Wherefore, let those concerning whom I have spoken, that should take their journey in haste\u2014again I say unto you, let them take their journey in haste.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 61:22",
+							"text": "And it mattereth not unto me, after a little, if it so be that they fill their mission, whether they go by water or by land; let this be as it is made known unto them according to their judgments hereafter.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 61:23",
+							"text": "And now, concerning my servants, Sidney Rigdon, Joseph Smith, Jun., and Oliver Cowdery, let them come not again upon the waters, save it be upon the canal, while journeying unto their homes; or in other words they shall not come upon the waters to journey, save upon the canal.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 61:24",
+							"text": "Behold, I, the Lord, have appointed a way for the journeying of my saints; and behold, this is the way\u2014that after they leave the canal they shall journey by land, inasmuch as they are commanded to journey and go up unto the land of Zion;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 61:25",
+							"text": "And they shall do like unto the children of Israel, pitching their tents by the way.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 61:26",
+							"text": "And, behold, this commandment you shall give unto all your brethren.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 61:27",
+							"text": "Nevertheless, unto whom is given power to command the waters, unto him it is given by the Spirit to know all his ways;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 61:28",
+							"text": "Wherefore, let him do as the Spirit of the living God commandeth him, whether upon the land or upon the waters, as it remaineth with me to do hereafter.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 61:29",
+							"text": "And unto you is given the course for the saints, or the way for the saints of the camp of the Lord, to journey.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 61:30",
+							"text": "And again, verily I say unto you, my servants, Sidney Rigdon, Joseph Smith, Jun., and Oliver Cowdery, shall not open their mouths in the congregations of the wicked until they arrive at Cincinnati;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 61:31",
+							"text": "And in that place they shall lift up their voices unto God against that people, yea, unto him whose anger is kindled against their wickedness, a people who are well-nigh ripened for destruction.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 61:32",
+							"text": "And from thence let them journey for the congregations of their brethren, for their labors even now are wanted more abundantly among them than among the congregations of the wicked.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 61:33",
+							"text": "And now, concerning the residue, let them journey and declare the word among the congregations of the wicked, inasmuch as it is given;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 61:34",
+							"text": "And inasmuch as they do this they shall rid their garments, and they shall be spotless before me.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 61:35",
+							"text": "And let them journey together, or two by two, as seemeth them good, only let my servant Reynolds Cahoon, and my servant Samuel H. Smith, with whom I am well pleased, be not separated until they return to their homes, and this for a wise purpose in me.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 61:36",
+							"text": "And now, verily I say unto you, and what I say unto one I say unto all, be of good cheer, little children; for I am in your midst, and I have not forsaken you;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 61:37",
+							"text": "And inasmuch as you have humbled yourselves before me, the blessings of the kingdom are yours.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 61:38",
+							"text": "Gird up your loins and be watchful and be sober, looking forth for the coming of the Son of Man, for he cometh in an hour you think not.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 61:39",
+							"text": "Pray always that you enter not into temptation, that you may abide the day of his coming, whether in life or in death. Even so. Amen.",
+							"verse": 39
+						}
+					]
+				},
+				{
+					"chapter": 62,
+					"reference": "D&C 62",
+					"verses": [{
+							"reference": "D&C 62:1",
+							"text": "Behold, and hearken, O ye elders of my church, saith the Lord your God, even Jesus Christ, your advocate, who knoweth the weakness of man and how to succor them who are tempted.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 62:2",
+							"text": "And verily mine eyes are upon those who have not as yet gone up unto the land of Zion; wherefore your mission is not yet full.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 62:3",
+							"text": "Nevertheless, ye are blessed, for the testimony which ye have borne is recorded in heaven for the angels to look upon; and they rejoice over you, and your sins are forgiven you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 62:4",
+							"text": "And now continue your journey. Assemble yourselves upon the land of Zion; and hold a meeting and rejoice together, and offer a sacrament unto the Most High.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 62:5",
+							"text": "And then you may return to bear record, yea, even altogether, or two by two, as seemeth you good, it mattereth not unto me; only be faithful, and declare glad tidings unto the inhabitants of the earth, or among the congregations of the wicked.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 62:6",
+							"text": "Behold, I, the Lord, have brought you together that the promise might be fulfilled, that the faithful among you should be preserved and rejoice together in the land of Missouri. I, the Lord, promise the faithful and cannot lie.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 62:7",
+							"text": "I, the Lord, am willing, if any among you desire to ride upon horses, or upon mules, or in chariots, he shall receive this blessing, if he receive it from the hand of the Lord, with a thankful heart in all things.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 62:8",
+							"text": "These things remain with you to do according to judgment and the directions of the Spirit.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 62:9",
+							"text": "Behold, the kingdom is yours. And behold, and lo, I am with the faithful always. Even so. Amen.",
+							"verse": 9
+						}
+					]
+				},
+				{
+					"chapter": 63,
+					"reference": "D&C 63",
+					"verses": [{
+							"reference": "D&C 63:1",
+							"text": "Hearken, O ye people, and open your hearts and give ear from afar; and listen, you that call yourselves the people of the Lord, and hear the word of the Lord and his will concerning you.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 63:2",
+							"text": "Yea, verily, I say, hear the word of him whose anger is kindled against the wicked and rebellious;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 63:3",
+							"text": "Who willeth to take even them whom he will take, and preserveth in life them whom he will preserve;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 63:4",
+							"text": "Who buildeth up at his own will and pleasure; and destroyeth when he pleases, and is able to cast the soul down to hell.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 63:5",
+							"text": "Behold, I, the Lord, utter my voice, and it shall be obeyed.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 63:6",
+							"text": "Wherefore, verily I say, let the wicked take heed, and let the rebellious fear and tremble; and let the unbelieving hold their lips, for the day of wrath shall come upon them as a whirlwind, and all flesh shall know that I am God.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 63:7",
+							"text": "And he that seeketh signs shall see signs, but not unto salvation.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 63:8",
+							"text": "Verily, I say unto you, there are those among you who seek signs, and there have been such even from the beginning;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 63:9",
+							"text": "But, behold, faith cometh not by signs, but signs follow those that believe.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 63:10",
+							"text": "Yea, signs come by faith, not by the will of men, nor as they please, but by the will of God.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 63:11",
+							"text": "Yea, signs come by faith, unto mighty works, for without faith no man pleaseth God; and with whom God is angry he is not well pleased; wherefore, unto such he showeth no signs, only in wrath unto their condemnation.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 63:12",
+							"text": "Wherefore, I, the Lord, am not pleased with those among you who have sought after signs and wonders for faith, and not for the good of men unto my glory.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 63:13",
+							"text": "Nevertheless, I give commandments, and many have turned away from my commandments and have not kept them.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 63:14",
+							"text": "There were among you adulterers and adulteresses; some of whom have turned away from you, and others remain with you that hereafter shall be revealed.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 63:15",
+							"text": "Let such beware and repent speedily, lest judgment shall come upon them as a snare, and their folly shall be made manifest, and their works shall follow them in the eyes of the people.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 63:16",
+							"text": "And verily I say unto you, as I have said before, he that looketh on a woman to lust after her, or if any shall commit adultery in their hearts, they shall not have the Spirit, but shall deny the faith and shall fear.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 63:17",
+							"text": "Wherefore, I, the Lord, have said that the fearful, and the unbelieving, and all liars, and whosoever loveth and maketh a lie, and the whoremonger, and the sorcerer, shall have their part in that lake which burneth with fire and brimstone, which is the second death.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 63:18",
+							"text": "Verily I say, that they shall not have part in the first resurrection.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 63:19",
+							"text": "And now behold, I, the Lord, say unto you that ye are not justified, because these things are among you.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 63:20",
+							"text": "Nevertheless, he that endureth in faith and doeth my will, the same shall overcome, and shall receive an inheritance upon the earth when the day of transfiguration shall come;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 63:21",
+							"text": "When the earth shall be transfigured, even according to the pattern which was shown unto mine apostles upon the mount; of which account the fulness ye have not yet received.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 63:22",
+							"text": "And now, verily I say unto you, that as I said that I would make known my will unto you, behold I will make it known unto you, not by the way of commandment, for there are many who observe not to keep my commandments.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 63:23",
+							"text": "But unto him that keepeth my commandments I will give the mysteries of my kingdom, and the same shall be in him a well of living water, springing up unto everlasting life.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 63:24",
+							"text": "And now, behold, this is the will of the Lord your God concerning his saints, that they should assemble themselves together unto the land of Zion, not in haste, lest there should be confusion, which bringeth pestilence.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 63:25",
+							"text": "Behold, the land of Zion\u2014I, the Lord, hold it in mine own hands;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 63:26",
+							"text": "Nevertheless, I, the Lord, render unto C\u00e6sar the things which are C\u00e6sar's.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 63:27",
+							"text": "Wherefore, I the Lord will that you should purchase the lands, that you may have advantage of the world, that you may have claim on the world, that they may not be stirred up unto anger.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 63:28",
+							"text": "For Satan putteth it into their hearts to anger against you, and to the shedding of blood.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 63:29",
+							"text": "Wherefore, the land of Zion shall not be obtained but by purchase or by blood, otherwise there is none inheritance for you.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 63:30",
+							"text": "And if by purchase, behold you are blessed;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 63:31",
+							"text": "And if by blood, as you are forbidden to shed blood, lo, your enemies are upon you, and ye shall be scourged from city to city, and from synagogue to synagogue, and but few shall stand to receive an inheritance.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 63:32",
+							"text": "I, the Lord, am angry with the wicked; I am holding my Spirit from the inhabitants of the earth.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 63:33",
+							"text": "I have sworn in my wrath, and decreed wars upon the face of the earth, and the wicked shall slay the wicked, and fear shall come upon every man;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 63:34",
+							"text": "And the saints also shall hardly escape; nevertheless, I, the Lord, am with them, and will come down in heaven from the presence of my Father and consume the wicked with unquenchable fire.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 63:35",
+							"text": "And behold, this is not yet, but by and by.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 63:36",
+							"text": "Wherefore, seeing that I, the Lord, have decreed all these things upon the face of the earth, I will that my saints should be assembled upon the land of Zion;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 63:37",
+							"text": "And that every man should take righteousness in his hands and faithfulness upon his loins, and lift a warning voice unto the inhabitants of the earth; and declare both by word and by flight that desolation shall come upon the wicked.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 63:38",
+							"text": "Wherefore, let my disciples in Kirtland arrange their temporal concerns, who dwell upon this farm.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 63:39",
+							"text": "Let my servant Titus Billings, who has the care thereof, dispose of the land, that he may be prepared in the coming spring to take his journey up unto the land of Zion, with those that dwell upon the face thereof, excepting those whom I shall reserve unto myself, that shall not go until I shall command them.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 63:40",
+							"text": "And let all the moneys which can be spared, it mattereth not unto me whether it be little or much, be sent up unto the land of Zion, unto them whom I have appointed to receive.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 63:41",
+							"text": "Behold, I, the Lord, will give unto my servant Joseph Smith, Jun., power that he shall be enabled to discern by the Spirit those who shall go up unto the land of Zion, and those of my disciples who shall tarry.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 63:42",
+							"text": "Let my servant Newel K. Whitney retain his store, or in other words, the store, yet for a little season.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 63:43",
+							"text": "Nevertheless, let him impart all the money which he can impart, to be sent up unto the land of Zion.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 63:44",
+							"text": "Behold, these things are in his own hands, let him do according to wisdom.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 63:45",
+							"text": "Verily I say, let him be ordained as an agent unto the disciples that shall tarry, and let him be ordained unto this power;",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 63:46",
+							"text": "And now speedily visit the churches, expounding these things unto them, with my servant Oliver Cowdery. Behold, this is my will, obtaining moneys even as I have directed.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 63:47",
+							"text": "He that is faithful and endureth shall overcome the world.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 63:48",
+							"text": "He that sendeth up treasures unto the land of Zion shall receive an inheritance in this world, and his works shall follow him, and also a reward in the world to come.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 63:49",
+							"text": "Yea, and blessed are the dead that die in the Lord, from henceforth, when the Lord shall come, and old things shall pass away, and all things become new, they shall rise from the dead and shall not die after, and shall receive an inheritance before the Lord, in the holy city.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 63:50",
+							"text": "And he that liveth when the Lord shall come, and hath kept the faith, blessed is he; nevertheless, it is appointed to him to die at the age of man.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 63:51",
+							"text": "Wherefore, children shall grow up until they become old; old men shall die; but they shall not sleep in the dust, but they shall be changed in the twinkling of an eye.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 63:52",
+							"text": "Wherefore, for this cause preached the apostles unto the world the resurrection of the dead.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 63:53",
+							"text": "These things are the things that ye must look for; and, speaking after the manner of the Lord, they are now nigh at hand, and in a time to come, even in the day of the coming of the Son of Man.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 63:54",
+							"text": "And until that hour there will be foolish virgins among the wise; and at that hour cometh an entire separation of the righteous and the wicked; and in that day will I send mine angels to pluck out the wicked and cast them into unquenchable fire.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 63:55",
+							"text": "And now behold, verily I say unto you, I, the Lord, am not pleased with my servant Sidney Rigdon; he exalted himself in his heart, and received not counsel, but grieved the Spirit;",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 63:56",
+							"text": "Wherefore his writing is not acceptable unto the Lord, and he shall make another; and if the Lord receive it not, behold he standeth no longer in the office to which I have appointed him.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 63:57",
+							"text": "And again, verily I say unto you, those who desire in their hearts, in meekness, to warn sinners to repentance, let them be ordained unto this power.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 63:58",
+							"text": "For this is a day of warning, and not a day of many words. For I, the Lord, am not to be mocked in the last days.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 63:59",
+							"text": "Behold, I am from above, and my power lieth beneath. I am over all, and in all, and through all, and search all things, and the day cometh that all things shall be subject unto me.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 63:60",
+							"text": "Behold, I am Alpha and Omega, even Jesus Christ.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 63:61",
+							"text": "Wherefore, let all men beware how they take my name in their lips\u2014",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 63:62",
+							"text": "For behold, verily I say, that many there be who are under this condemnation, who use the name of the Lord, and use it in vain, having not authority.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 63:63",
+							"text": "Wherefore, let the church repent of their sins, and I, the Lord, will own them; otherwise they shall be cut off.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 63:64",
+							"text": "Remember that that which cometh from above is sacred, and must be spoken with care, and by constraint of the Spirit; and in this there is no condemnation, and ye receive the Spirit through prayer; wherefore, without this there remaineth condemnation.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 63:65",
+							"text": "Let my servants, Joseph Smith, Jun., and Sidney Rigdon, seek them a home, as they are taught through prayer by the Spirit.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 63:66",
+							"text": "These things remain to overcome through patience, that such may receive a more exceeding and eternal weight of glory, otherwise, a greater condemnation. Amen.",
+							"verse": 66
+						}
+					]
+				},
+				{
+					"chapter": 64,
+					"reference": "D&C 64",
+					"verses": [{
+							"reference": "D&C 64:1",
+							"text": "Behold, thus saith the Lord your God unto you, O ye elders of my church, hearken ye and hear, and receive my will concerning you.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 64:2",
+							"text": "For verily I say unto you, I will that ye should overcome the world; wherefore I will have compassion upon you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 64:3",
+							"text": "There are those among you who have sinned; but verily I say, for this once, for mine own glory, and for the salvation of souls, I have forgiven you your sins.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 64:4",
+							"text": "I will be merciful unto you, for I have given unto you the kingdom.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 64:5",
+							"text": "And the keys of the mysteries of the kingdom shall not be taken from my servant Joseph Smith, Jun., through the means I have appointed, while he liveth, inasmuch as he obeyeth mine ordinances.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 64:6",
+							"text": "There are those who have sought occasion against him without cause;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 64:7",
+							"text": "Nevertheless, he has sinned; but verily I say unto you, I, the Lord, forgive sins unto those who confess their sins before me and ask forgiveness, who have not sinned unto death.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 64:8",
+							"text": "My disciples, in days of old, sought occasion against one another and forgave not one another in their hearts; and for this evil they were afflicted and sorely chastened.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 64:9",
+							"text": "Wherefore, I say unto you, that ye ought to forgive one another; for he that forgiveth not his brother his trespasses standeth condemned before the Lord; for there remaineth in him the greater sin.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 64:10",
+							"text": "I, the Lord, will forgive whom I will forgive, but of you it is required to forgive all men.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 64:11",
+							"text": "And ye ought to say in your hearts\u2014let God judge between me and thee, and reward thee according to thy deeds.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 64:12",
+							"text": "And him that repenteth not of his sins, and confesseth them not, ye shall bring before the church, and do with him as the scripture saith unto you, either by commandment or by revelation.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 64:13",
+							"text": "And this ye shall do that God may be glorified\u2014not because ye forgive not, having not compassion, but that ye may be justified in the eyes of the law, that ye may not offend him who is your lawgiver\u2014",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 64:14",
+							"text": "Verily I say, for this cause ye shall do these things.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 64:15",
+							"text": "Behold, I, the Lord, was angry with him who was my servant Ezra Booth, and also my servant Isaac Morley, for they kept not the law, neither the commandment;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 64:16",
+							"text": "They sought evil in their hearts, and I, the Lord, withheld my Spirit. They condemned for evil that thing in which there was no evil; nevertheless I have forgiven my servant Isaac Morley.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 64:17",
+							"text": "And also my servant Edward Partridge, behold, he hath sinned, and Satan seeketh to destroy his soul; but when these things are made known unto them, and they repent of the evil, they shall be forgiven.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 64:18",
+							"text": "And now, verily I say that it is expedient in me that my servant Sidney Gilbert, after a few weeks, shall return upon his business, and to his agency in the land of Zion;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 64:19",
+							"text": "And that which he hath seen and heard may be made known unto my disciples, that they perish not. And for this cause have I spoken these things.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 64:20",
+							"text": "And again, I say unto you, that my servant Isaac Morley may not be tempted above that which he is able to bear, and counsel wrongfully to your hurt, I gave commandment that his farm should be sold.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 64:21",
+							"text": "I will not that my servant Frederick G. Williams should sell his farm, for I, the Lord, will to retain a strong hold in the land of Kirtland, for the space of five years, in the which I will not overthrow the wicked, that thereby I may save some.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 64:22",
+							"text": "And after that day, I, the Lord, will not hold any guilty that shall go with an open heart up to the land of Zion; for I, the Lord, require the hearts of the children of men.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 64:23",
+							"text": "Behold, now it is called today until the coming of the Son of Man, and verily it is a day of sacrifice, and a day for the tithing of my people; for he that is tithed shall not be burned at his coming.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 64:24",
+							"text": "For after today cometh the burning\u2014this is speaking after the manner of the Lord\u2014for verily I say, tomorrow all the proud and they that do wickedly shall be as stubble; and I will burn them up, for I am the Lord of Hosts; and I will not spare any that remain in Babylon.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 64:25",
+							"text": "Wherefore, if ye believe me, ye will labor while it is called today.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 64:26",
+							"text": "And it is not meet that my servants, Newel K. Whitney and Sidney Gilbert, should sell their store and their possessions here; for this is not wisdom until the residue of the church, which remaineth in this place, shall go up unto the land of Zion.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 64:27",
+							"text": "Behold, it is said in my laws, or forbidden, to get in debt to thine enemies;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 64:28",
+							"text": "But behold, it is not said at any time that the Lord should not take when he please, and pay as seemeth him good.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 64:29",
+							"text": "Wherefore, as ye are agents, ye are on the Lord's errand; and whatever ye do according to the will of the Lord is the Lord's business.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 64:30",
+							"text": "And he hath set you to provide for his saints in these last days, that they may obtain an inheritance in the land of Zion.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 64:31",
+							"text": "And behold, I, the Lord, declare unto you, and my words are sure and shall not fail, that they shall obtain it.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 64:32",
+							"text": "But all things must come to pass in their time.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 64:33",
+							"text": "Wherefore, be not weary in well-doing, for ye are laying the foundation of a great work. And out of small things proceedeth that which is great.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 64:34",
+							"text": "Behold, the Lord requireth the heart and a willing mind; and the willing and obedient shall eat the good of the land of Zion in these last days.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 64:35",
+							"text": "And the rebellious shall be cut off out of the land of Zion, and shall be sent away, and shall not inherit the land.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 64:36",
+							"text": "For, verily I say that the rebellious are not of the blood of Ephraim, wherefore they shall be plucked out.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 64:37",
+							"text": "Behold, I, the Lord, have made my church in these last days like unto a judge sitting on a hill, or in a high place, to judge the nations.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 64:38",
+							"text": "For it shall come to pass that the inhabitants of Zion shall judge all things pertaining to Zion.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 64:39",
+							"text": "And liars and hypocrites shall be proved by them, and they who are not apostles and prophets shall be known.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 64:40",
+							"text": "And even the bishop, who is a judge, and his counselors, if they are not faithful in their stewardships shall be condemned, and others shall be planted in their stead.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 64:41",
+							"text": "For, behold, I say unto you that Zion shall flourish, and the glory of the Lord shall be upon her;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 64:42",
+							"text": "And she shall be an ensign unto the people, and there shall come unto her out of every nation under heaven.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 64:43",
+							"text": "And the day shall come when the nations of the earth shall tremble because of her, and shall fear because of her terrible ones. The Lord hath spoken it. Amen.",
+							"verse": 43
+						}
+					]
+				},
+				{
+					"chapter": 65,
+					"reference": "D&C 65",
+					"verses": [{
+							"reference": "D&C 65:1",
+							"text": "Hearken, and lo, a voice as of one sent down from on high, who is mighty and powerful, whose going forth is unto the ends of the earth, yea, whose voice is unto men\u2014Prepare ye the way of the Lord, make his paths straight.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 65:2",
+							"text": "The keys of the kingdom of God are committed unto man on the earth, and from thence shall the gospel roll forth unto the ends of the earth, as the stone which is cut out of the mountain without hands shall roll forth, until it has filled the whole earth.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 65:3",
+							"text": "Yea, a voice crying\u2014Prepare ye the way of the Lord, prepare ye the supper of the Lamb, make ready for the Bridegroom.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 65:4",
+							"text": "Pray unto the Lord, call upon his holy name, make known his wonderful works among the people.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 65:5",
+							"text": "Call upon the Lord, that his kingdom may go forth upon the earth, that the inhabitants thereof may receive it, and be prepared for the days to come, in the which the Son of Man shall come down in heaven, clothed in the brightness of his glory, to meet the kingdom of God which is set up on the earth.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 65:6",
+							"text": "Wherefore, may the kingdom of God go forth, that the kingdom of heaven may come, that thou, O God, mayest be glorified in heaven so on earth, that thine enemies may be subdued; for thine is the honor, power and glory, forever and ever. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 66,
+					"reference": "D&C 66",
+					"verses": [{
+							"reference": "D&C 66:1",
+							"text": "Behold, thus saith the Lord unto my servant William E. McLellin\u2014Blessed are you, inasmuch as you have turned away from your iniquities, and have received my truths, saith the Lord your Redeemer, the Savior of the world, even of as many as believe on my name.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 66:2",
+							"text": "Verily I say unto you, blessed are you for receiving mine everlasting covenant, even the fulness of my gospel, sent forth unto the children of men, that they might have life and be made partakers of the glories which are to be revealed in the last days, as it was written by the prophets and apostles in days of old.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 66:3",
+							"text": "Verily I say unto you, my servant William, that you are clean, but not all; repent, therefore, of those things which are not pleasing in my sight, saith the Lord, for the Lord will show them unto you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 66:4",
+							"text": "And now, verily, I, the Lord, will show unto you what I will concerning you, or what is my will concerning you.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 66:5",
+							"text": "Behold, verily I say unto you, that it is my will that you should proclaim my gospel from land to land, and from city to city, yea, in those regions round about where it has not been proclaimed.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 66:6",
+							"text": "Tarry not many days in this place; go not up unto the land of Zion as yet; but inasmuch as you can send, send; otherwise, think not of thy property.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 66:7",
+							"text": "Go unto the eastern lands, bear testimony in every place, unto every people and in their synagogues, reasoning with the people.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 66:8",
+							"text": "Let my servant Samuel H. Smith go with you, and forsake him not, and give him thine instructions; and he that is faithful shall be made strong in every place; and I, the Lord, will go with you.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 66:9",
+							"text": "Lay your hands upon the sick, and they shall recover. Return not till I, the Lord, shall send you. Be patient in affliction. Ask, and ye shall receive; knock, and it shall be opened unto you.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 66:10",
+							"text": "Seek not to be cumbered. Forsake all unrighteousness. Commit not adultery\u2014a temptation with which thou hast been troubled.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 66:11",
+							"text": "Keep these sayings, for they are true and faithful; and thou shalt magnify thine office, and push many people to Zion with songs of everlasting joy upon their heads.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 66:12",
+							"text": "Continue in these things even unto the end, and you shall have a crown of eternal life at the right hand of my Father, who is full of grace and truth.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 66:13",
+							"text": "Verily, thus saith the Lord your God, your Redeemer, even Jesus Christ. Amen.",
+							"verse": 13
+						}
+					]
+				},
+				{
+					"chapter": 67,
+					"reference": "D&C 67",
+					"verses": [{
+							"reference": "D&C 67:1",
+							"text": "Behold and hearken, O ye elders of my church, who have assembled yourselves together, whose prayers I have heard, and whose hearts I know, and whose desires have come up before me.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 67:2",
+							"text": "Behold and lo, mine eyes are upon you, and the heavens and the earth are in mine hands, and the riches of eternity are mine to give.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 67:3",
+							"text": "Ye endeavored to believe that ye should receive the blessing which was offered unto you; but behold, verily I say unto you there were fears in your hearts, and verily this is the reason that ye did not receive.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 67:4",
+							"text": "And now I, the Lord, give unto you a testimony of the truth of these commandments which are lying before you.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 67:5",
+							"text": "Your eyes have been upon my servant Joseph Smith, Jun., and his language you have known, and his imperfections you have known; and you have sought in your hearts knowledge that you might express beyond his language; this you also know.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 67:6",
+							"text": "Now, seek ye out of the Book of Commandments, even the least that is among them, and appoint him that is the most wise among you;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 67:7",
+							"text": "Or, if there be any among you that shall make one like unto it, then ye are justified in saying that ye do not know that they are true;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 67:8",
+							"text": "But if ye cannot make one like unto it, ye are under condemnation if ye do not bear record that they are true.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 67:9",
+							"text": "For ye know that there is no unrighteousness in them, and that which is righteous cometh down from above, from the Father of lights.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 67:10",
+							"text": "And again, verily I say unto you that it is your privilege, and a promise I give unto you that have been ordained unto this ministry, that inasmuch as you strip yourselves from jealousies and fears, and humble yourselves before me, for ye are not sufficiently humble, the veil shall be rent and you shall see me and know that I am\u2014not with the carnal neither natural mind, but with the spiritual.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 67:11",
+							"text": "For no man has seen God at any time in the flesh, except quickened by the Spirit of God.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 67:12",
+							"text": "Neither can any natural man abide the presence of God, neither after the carnal mind.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 67:13",
+							"text": "Ye are not able to abide the presence of God now, neither the ministering of angels; wherefore, continue in patience until ye are perfected.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 67:14",
+							"text": "Let not your minds turn back; and when ye are worthy, in mine own due time, ye shall see and know that which was conferred upon you by the hands of my servant Joseph Smith, Jun. Amen.",
+							"verse": 14
+						}
+					]
+				},
+				{
+					"chapter": 68,
+					"reference": "D&C 68",
+					"verses": [{
+							"reference": "D&C 68:1",
+							"text": "My servant, Orson Hyde, was called by his ordination to proclaim the everlasting gospel, by the Spirit of the living God, from people to people, and from land to land, in the congregations of the wicked, in their synagogues, reasoning with and expounding all scriptures unto them.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 68:2",
+							"text": "And, behold, and lo, this is an ensample unto all those who were ordained unto this priesthood, whose mission is appointed unto them to go forth\u2014",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 68:3",
+							"text": "And this is the ensample unto them, that they shall speak as they are moved upon by the Holy Ghost.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 68:4",
+							"text": "And whatsoever they shall speak when moved upon by the Holy Ghost shall be scripture, shall be the will of the Lord, shall be the mind of the Lord, shall be the word of the Lord, shall be the voice of the Lord, and the power of God unto salvation.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 68:5",
+							"text": "Behold, this is the promise of the Lord unto you, O ye my servants.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 68:6",
+							"text": "Wherefore, be of good cheer, and do not fear, for I the Lord am with you, and will stand by you; and ye shall bear record of me, even Jesus Christ, that I am the Son of the living God, that I was, that I am, and that I am to come.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 68:7",
+							"text": "This is the word of the Lord unto you, my servant Orson Hyde, and also unto my servant Luke Johnson, and unto my servant Lyman Johnson, and unto my servant William E. McLellin, and unto all the faithful elders of my church\u2014",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 68:8",
+							"text": "Go ye into all the world, preach the gospel to every creature, acting in the authority which I have given you, baptizing in the name of the Father, and of the Son, and of the Holy Ghost.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 68:9",
+							"text": "And he that believeth and is baptized shall be saved, and he that believeth not shall be damned.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 68:10",
+							"text": "And he that believeth shall be blest with signs following, even as it is written.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 68:11",
+							"text": "And unto you it shall be given to know the signs of the times, and the signs of the coming of the Son of Man;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 68:12",
+							"text": "And of as many as the Father shall bear record, to you shall be given power to seal them up unto eternal life. Amen.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 68:13",
+							"text": "And now, concerning the items in addition to the covenants and commandments, they are these\u2014",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 68:14",
+							"text": "There remain hereafter, in the due time of the Lord, other bishops to be set apart unto the church, to minister even according to the first;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 68:15",
+							"text": "Wherefore they shall be high priests who are worthy, and they shall be appointed by the First Presidency of the Melchizedek Priesthood, except they be literal descendants of Aaron.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 68:16",
+							"text": "And if they be literal descendants of Aaron they have a legal right to the bishopric, if they are the firstborn among the sons of Aaron;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 68:17",
+							"text": "For the firstborn holds the right of the presidency over this priesthood, and the keys or authority of the same.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 68:18",
+							"text": "No man has a legal right to this office, to hold the keys of this priesthood, except he be a literal descendant and the firstborn of Aaron.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 68:19",
+							"text": "But, as a high priest of the Melchizedek Priesthood has authority to officiate in all the lesser offices he may officiate in the office of bishop when no literal descendant of Aaron can be found, provided he is called and set apart and ordained unto this power, under the hands of the First Presidency of the Melchizedek Priesthood.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 68:20",
+							"text": "And a literal descendant of Aaron, also, must be designated by this Presidency, and found worthy, and anointed, and ordained under the hands of this Presidency, otherwise they are not legally authorized to officiate in their priesthood.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 68:21",
+							"text": "But, by virtue of the decree concerning their right of the priesthood descending from father to son, they may claim their anointing if at any time they can prove their lineage, or do ascertain it by revelation from the Lord under the hands of the above named Presidency.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 68:22",
+							"text": "And again, no bishop or high priest who shall be set apart for this ministry shall be tried or condemned for any crime, save it be before the First Presidency of the church;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 68:23",
+							"text": "And inasmuch as he is found guilty before this Presidency, by testimony that cannot be impeached, he shall be condemned;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 68:24",
+							"text": "And if he repent he shall be forgiven, according to the covenants and commandments of the church.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 68:25",
+							"text": "And again, inasmuch as parents have children in Zion, or in any of her stakes which are organized, that teach them not to understand the doctrine of repentance, faith in Christ the Son of the living God, and of baptism and the gift of the Holy Ghost by the laying on of the hands, when eight years old, the sin be upon the heads of the parents.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 68:26",
+							"text": "For this shall be a law unto the inhabitants of Zion, or in any of her stakes which are organized.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 68:27",
+							"text": "And their children shall be baptized for the remission of their sins when eight years old, and receive the laying on of the hands.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 68:28",
+							"text": "And they shall also teach their children to pray, and to walk uprightly before the Lord.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 68:29",
+							"text": "And the inhabitants of Zion shall also observe the Sabbath day to keep it holy.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 68:30",
+							"text": "And the inhabitants of Zion also shall remember their labors, inasmuch as they are appointed to labor, in all faithfulness; for the idler shall be had in remembrance before the Lord.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 68:31",
+							"text": "Now, I, the Lord, am not well pleased with the inhabitants of Zion, for there are idlers among them; and their children are also growing up in wickedness; they also seek not earnestly the riches of eternity, but their eyes are full of greediness.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 68:32",
+							"text": "These things ought not to be, and must be done away from among them; wherefore, let my servant Oliver Cowdery carry these sayings unto the land of Zion.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 68:33",
+							"text": "And a commandment I give unto them\u2014that he that observeth not his prayers before the Lord in the season thereof, let him be had in remembrance before the judge of my people.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 68:34",
+							"text": "These sayings are true and faithful; wherefore, transgress them not, neither take therefrom.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 68:35",
+							"text": "Behold, I am Alpha and Omega, and I come quickly. Amen.",
+							"verse": 35
+						}
+					]
+				},
+				{
+					"chapter": 69,
+					"reference": "D&C 69",
+					"verses": [{
+							"reference": "D&C 69:1",
+							"text": "Hearken unto me, saith the Lord your God, for my servant Oliver Cowdery's sake. It is not wisdom in me that he should be entrusted with the commandments and the moneys which he shall carry unto the land of Zion, except one go with him who will be true and faithful.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 69:2",
+							"text": "Wherefore, I, the Lord, will that my servant, John Whitmer, should go with my servant Oliver Cowdery;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 69:3",
+							"text": "And also that he shall continue in writing and making a history of all the important things which he shall observe and know concerning my church;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 69:4",
+							"text": "And also that he receive counsel and assistance from my servant Oliver Cowdery and others.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 69:5",
+							"text": "And also, my servants who are abroad in the earth should send forth the accounts of their stewardships to the land of Zion;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 69:6",
+							"text": "For the land of Zion shall be a seat and a place to receive and do all these things.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 69:7",
+							"text": "Nevertheless, let my servant John Whitmer travel many times from place to place, and from church to church, that he may the more easily obtain knowledge\u2014",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 69:8",
+							"text": "Preaching and expounding, writing, copying, selecting, and obtaining all things which shall be for the good of the church, and for the rising generations that shall grow up on the land of Zion, to possess it from generation to generation, forever and ever. Amen.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 70,
+					"reference": "D&C 70",
+					"verses": [{
+							"reference": "D&C 70:1",
+							"text": "Behold, and hearken, O ye inhabitants of Zion, and all ye people of my church who are afar off, and hear the word of the Lord which I give unto my servant Joseph Smith, Jun., and also unto my servant Martin Harris, and also unto my servant Oliver Cowdery, and also unto my servant John Whitmer, and also unto my servant Sidney Rigdon, and also unto my servant William W. Phelps, by the way of commandment unto them.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 70:2",
+							"text": "For I give unto them a commandment; wherefore hearken and hear, for thus saith the Lord unto them\u2014",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 70:3",
+							"text": "I, the Lord, have appointed them, and ordained them to be stewards over the revelations and commandments which I have given unto them, and which I shall hereafter give unto them;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 70:4",
+							"text": "And an account of this stewardship will I require of them in the day of judgment.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 70:5",
+							"text": "Wherefore, I have appointed unto them, and this is their business in the church of God, to manage them and the concerns thereof, yea, the benefits thereof.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 70:6",
+							"text": "Wherefore, a commandment I give unto them, that they shall not give these things unto the church, neither unto the world;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 70:7",
+							"text": "Nevertheless, inasmuch as they receive more than is needful for their necessities and their wants, it shall be given into my storehouse;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 70:8",
+							"text": "And the benefits shall be consecrated unto the inhabitants of Zion, and unto their generations, inasmuch as they become heirs according to the laws of the kingdom.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 70:9",
+							"text": "Behold, this is what the Lord requires of every man in his stewardship, even as I, the Lord, have appointed or shall hereafter appoint unto any man.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 70:10",
+							"text": "And behold, none are exempt from this law who belong to the church of the living God;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 70:11",
+							"text": "Yea, neither the bishop, neither the agent who keepeth the Lord's storehouse, neither he who is appointed in a stewardship over temporal things.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 70:12",
+							"text": "He who is appointed to administer spiritual things, the same is worthy of his hire, even as those who are appointed to a stewardship to administer in temporal things;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 70:13",
+							"text": "Yea, even more abundantly, which abundance is multiplied unto them through the manifestations of the Spirit.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 70:14",
+							"text": "Nevertheless, in your temporal things you shall be equal, and this not grudgingly, otherwise the abundance of the manifestations of the Spirit shall be withheld.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 70:15",
+							"text": "Now, this commandment I give unto my servants for their benefit while they remain, for a manifestation of my blessings upon their heads, and for a reward of their diligence and for their security;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 70:16",
+							"text": "For food and for raiment; for an inheritance; for houses and for lands, in whatsoever circumstances I, the Lord, shall place them, and whithersoever I, the Lord, shall send them.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 70:17",
+							"text": "For they have been faithful over many things, and have done well inasmuch as they have not sinned.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 70:18",
+							"text": "Behold, I, the Lord, am merciful and will bless them, and they shall enter into the joy of these things. Even so. Amen.",
+							"verse": 18
+						}
+					]
+				},
+				{
+					"chapter": 71,
+					"reference": "D&C 71",
+					"verses": [{
+							"reference": "D&C 71:1",
+							"text": "Behold, thus saith the Lord unto you my servants Joseph Smith, Jun., and Sidney Rigdon, that the time has verily come that it is necessary and expedient in me that you should open your mouths in proclaiming my gospel, the things of the kingdom, expounding the mysteries thereof out of the scriptures, according to that portion of Spirit and power which shall be given unto you, even as I will.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 71:2",
+							"text": "Verily I say unto you, proclaim unto the world in the regions round about, and in the church also, for the space of a season, even until it shall be made known unto you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 71:3",
+							"text": "Verily this is a mission for a season, which I give unto you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 71:4",
+							"text": "Wherefore, labor ye in my vineyard. Call upon the inhabitants of the earth, and bear record, and prepare the way for the commandments and revelations which are to come.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 71:5",
+							"text": "Now, behold this is wisdom; whoso readeth, let him understand and receive also;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 71:6",
+							"text": "For unto him that receiveth it shall be given more abundantly, even power.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 71:7",
+							"text": "Wherefore, confound your enemies; call upon them to meet you both in public and in private; and inasmuch as ye are faithful their shame shall be made manifest.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 71:8",
+							"text": "Wherefore, let them bring forth their strong reasons against the Lord.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 71:9",
+							"text": "Verily, thus saith the Lord unto you\u2014there is no weapon that is formed against you shall prosper;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 71:10",
+							"text": "And if any man lift his voice against you he shall be confounded in mine own due time.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 71:11",
+							"text": "Wherefore, keep my commandments; they are true and faithful. Even so. Amen.",
+							"verse": 11
+						}
+					]
+				},
+				{
+					"chapter": 72,
+					"reference": "D&C 72",
+					"verses": [{
+							"reference": "D&C 72:1",
+							"text": "Hearken, and listen to the voice of the Lord, O ye who have assembled yourselves together, who are the high priests of my church, to whom the kingdom and power have been given.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 72:2",
+							"text": "For verily thus saith the Lord, it is expedient in me for a bishop to be appointed unto you, or of you, unto the church in this part of the Lord's vineyard.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 72:3",
+							"text": "And verily in this thing ye have done wisely, for it is required of the Lord, at the hand of every steward, to render an account of his stewardship, both in time and in eternity.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 72:4",
+							"text": "For he who is faithful and wise in time is accounted worthy to inherit the mansions prepared for him of my Father.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 72:5",
+							"text": "Verily I say unto you, the elders of the church in this part of my vineyard shall render an account of their stewardship unto the bishop, who shall be appointed of me in this part of my vineyard.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 72:6",
+							"text": "These things shall be had on record, to be handed over unto the bishop in Zion.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 72:7",
+							"text": "And the duty of the bishop shall be made known by the commandments which have been given, and the voice of the conference.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 72:8",
+							"text": "And now, verily I say unto you, my servant Newel K. Whitney is the man who shall be appointed and ordained unto this power. This is the will of the Lord your God, your Redeemer. Even so. Amen.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 72:9",
+							"text": "The word of the Lord, in addition to the law which has been given, making known the duty of the bishop who has been ordained unto the church in this part of the vineyard, which is verily this\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 72:10",
+							"text": "To keep the Lord's storehouse; to receive the funds of the church in this part of the vineyard;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 72:11",
+							"text": "To take an account of the elders as before has been commanded; and to administer to their wants, who shall pay for that which they receive, inasmuch as they have wherewith to pay;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 72:12",
+							"text": "That this also may be consecrated to the good of the church, to the poor and needy.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 72:13",
+							"text": "And he who hath not wherewith to pay, an account shall be taken and handed over to the bishop of Zion, who shall pay the debt out of that which the Lord shall put into his hands.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 72:14",
+							"text": "And the labors of the faithful who labor in spiritual things, in administering the gospel and the things of the kingdom unto the church, and unto the world, shall answer the debt unto the bishop in Zion;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 72:15",
+							"text": "Thus it cometh out of the church, for according to the law every man that cometh up to Zion must lay all things before the bishop in Zion.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 72:16",
+							"text": "And now, verily I say unto you, that as every elder in this part of the vineyard must give an account of his stewardship unto the bishop in this part of the vineyard\u2014",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 72:17",
+							"text": "A certificate from the judge or bishop in this part of the vineyard, unto the bishop in Zion, rendereth every man acceptable, and answereth all things, for an inheritance, and to be received as a wise steward and as a faithful laborer;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 72:18",
+							"text": "Otherwise he shall not be accepted of the bishop of Zion.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 72:19",
+							"text": "And now, verily I say unto you, let every elder who shall give an account unto the bishop of the church in this part of the vineyard be recommended by the church or churches, in which he labors, that he may render himself and his accounts approved in all things.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 72:20",
+							"text": "And again, let my servants who are appointed as stewards over the literary concerns of my church have claim for assistance upon the bishop or bishops in all things\u2014",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 72:21",
+							"text": "That the revelations may be published, and go forth unto the ends of the earth; that they also may obtain funds which shall benefit the church in all things;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 72:22",
+							"text": "That they also may render themselves approved in all things, and be accounted as wise stewards.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 72:23",
+							"text": "And now, behold, this shall be an ensample for all the extensive branches of my church, in whatsoever land they shall be established. And now I make an end of my sayings. Amen.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 72:24",
+							"text": "A few words in addition to the laws of the kingdom, respecting the members of the church\u2014they that are appointed by the Holy Spirit to go up unto Zion, and they who are privileged to go up unto Zion\u2014",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 72:25",
+							"text": "Let them carry up unto the bishop a certificate from three elders of the church, or a certificate from the bishop;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 72:26",
+							"text": "Otherwise he who shall go up unto the land of Zion shall not be accounted as a wise steward. This is also an ensample. Amen.",
+							"verse": 26
+						}
+					]
+				},
+				{
+					"chapter": 73,
+					"reference": "D&C 73",
+					"verses": [{
+							"reference": "D&C 73:1",
+							"text": "For verily, thus saith the Lord, it is expedient in me that they should continue preaching the gospel, and in exhortation to the churches in the regions round about, until conference;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 73:2",
+							"text": "And then, behold, it shall be made known unto them, by the voice of the conference, their several missions.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 73:3",
+							"text": "Now, verily I say unto you my servants, Joseph Smith, Jun., and Sidney Rigdon, saith the Lord, it is expedient to translate again;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 73:4",
+							"text": "And, inasmuch as it is practicable, to preach in the regions round about until conference; and after that it is expedient to continue the work of translation until it be finished.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 73:5",
+							"text": "And let this be a pattern unto the elders until further knowledge, even as it is written.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 73:6",
+							"text": "Now I give no more unto you at this time. Gird up your loins and be sober. Even so. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 74,
+					"reference": "D&C 74",
+					"verses": [{
+							"reference": "D&C 74:1",
+							"text": "For the unbelieving husband is sanctified by the wife, and the unbelieving wife is sanctified by the husband; else were your children unclean, but now are they holy.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 74:2",
+							"text": "Now, in the days of the apostles the law of circumcision was had among all the Jews who believed not the gospel of Jesus Christ.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 74:3",
+							"text": "And it came to pass that there arose a great contention among the people concerning the law of circumcision, for the unbelieving husband was desirous that his children should be circumcised and become subject to the law of Moses, which law was fulfilled.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 74:4",
+							"text": "And it came to pass that the children, being brought up in subjection to the law of Moses, gave heed to the traditions of their fathers and believed not the gospel of Christ, wherein they became unholy.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 74:5",
+							"text": "Wherefore, for this cause the apostle wrote unto the church, giving unto them a commandment, not of the Lord, but of himself, that a believer should not be united to an unbeliever; except the law of Moses should be done away among them,",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 74:6",
+							"text": "That their children might remain without circumcision; and that the tradition might be done away, which saith that little children are unholy; for it was had among the Jews;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 74:7",
+							"text": "But little children are holy, being sanctified through the atonement of Jesus Christ; and this is what the scriptures mean.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 75,
+					"reference": "D&C 75",
+					"verses": [{
+							"reference": "D&C 75:1",
+							"text": "Verily, verily, I say unto you, I who speak even by the voice of my Spirit, even Alpha and Omega, your Lord and your God\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 75:2",
+							"text": "Hearken, O ye who have given your names to go forth to proclaim my gospel, and to prune my vineyard.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 75:3",
+							"text": "Behold, I say unto you that it is my will that you should go forth and not tarry, neither be idle but labor with your might\u2014",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 75:4",
+							"text": "Lifting up your voices as with the sound of a trump, proclaiming the truth according to the revelations and commandments which I have given you.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 75:5",
+							"text": "And thus, if ye are faithful ye shall be laden with many sheaves, and crowned with honor, and glory, and immortality, and eternal life.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 75:6",
+							"text": "Therefore, verily I say unto my servant William E. McLellin, I revoke the commission which I gave unto him to go unto the eastern countries;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 75:7",
+							"text": "And I give unto him a new commission and a new commandment, in the which I, the Lord, chasten him for the murmurings of his heart;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 75:8",
+							"text": "And he sinned; nevertheless, I forgive him and say unto him again, Go ye into the south countries.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 75:9",
+							"text": "And let my servant Luke Johnson go with him, and proclaim the things which I have commanded them\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 75:10",
+							"text": "Calling on the name of the Lord for the Comforter, which shall teach them all things that are expedient for them\u2014",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 75:11",
+							"text": "Praying always that they faint not; and inasmuch as they do this, I will be with them even unto the end.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 75:12",
+							"text": "Behold, this is the will of the Lord your God concerning you. Even so. Amen.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 75:13",
+							"text": "And again, verily thus saith the Lord, let my servant Orson Hyde and my servant Samuel H. Smith take their journey into the eastern countries, and proclaim the things which I have commanded them; and inasmuch as they are faithful, lo, I will be with them even unto the end.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 75:14",
+							"text": "And again, verily I say unto my servant Lyman Johnson, and unto my servant Orson Pratt, they shall also take their journey into the eastern countries; and behold, and lo, I am with them also, even unto the end.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 75:15",
+							"text": "And again, I say unto my servant Asa Dodds, and unto my servant Calves Wilson, that they also shall take their journey unto the western countries, and proclaim my gospel, even as I have commanded them.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 75:16",
+							"text": "And he who is faithful shall overcome all things, and shall be lifted up at the last day.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 75:17",
+							"text": "And again, I say unto my servant Major N. Ashley, and my servant Burr Riggs, let them take their journey also into the south country.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 75:18",
+							"text": "Yea, let all those take their journey, as I have commanded them, going from house to house, and from village to village, and from city to city.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 75:19",
+							"text": "And in whatsoever house ye enter, and they receive you, leave your blessing upon that house.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 75:20",
+							"text": "And in whatsoever house ye enter, and they receive you not, ye shall depart speedily from that house, and shake off the dust of your feet as a testimony against them.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 75:21",
+							"text": "And you shall be filled with joy and gladness; and know this, that in the day of judgment you shall be judges of that house, and condemn them;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 75:22",
+							"text": "And it shall be more tolerable for the heathen in the day of judgment, than for that house; therefore, gird up your loins and be faithful, and ye shall overcome all things, and be lifted up at the last day. Even so. Amen.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 75:23",
+							"text": "And again, thus saith the Lord unto you, O ye elders of my church, who have given your names that you might know his will concerning you\u2014",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 75:24",
+							"text": "Behold, I say unto you, that it is the duty of the church to assist in supporting the families of those, and also to support the families of those who are called and must needs be sent unto the world to proclaim the gospel unto the world.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 75:25",
+							"text": "Wherefore, I, the Lord, give unto you this commandment, that ye obtain places for your families, inasmuch as your brethren are willing to open their hearts.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 75:26",
+							"text": "And let all such as can obtain places for their families, and support of the church for them, not fail to go into the world, whether to the east or to the west, or to the north, or to the south.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 75:27",
+							"text": "Let them ask and they shall receive, knock and it shall be opened unto them, and be made known from on high, even by the Comforter, whither they shall go.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 75:28",
+							"text": "And again, verily I say unto you, that every man who is obliged to provide for his own family, let him provide, and he shall in nowise lose his crown; and let him labor in the church.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 75:29",
+							"text": "Let every man be diligent in all things. And the idler shall not have place in the church, except he repent and mend his ways.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 75:30",
+							"text": "Wherefore, let my servant Simeon Carter and my servant Emer Harris be united in the ministry;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 75:31",
+							"text": "And also my servant Ezra Thayre and my servant Thomas B. Marsh;",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 75:32",
+							"text": "Also my servant Hyrum Smith and my servant Reynolds Cahoon;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 75:33",
+							"text": "And also my servant Daniel Stanton and my servant Seymour Brunson;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 75:34",
+							"text": "And also my servant Sylvester Smith and my servant Gideon Carter;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 75:35",
+							"text": "And also my servant Ruggles Eames and my servant Stephen Burnett;",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 75:36",
+							"text": "And also my servant Micah B. Welton and also my servant Eden Smith. Even so. Amen.",
+							"verse": 36
+						}
+					]
+				}
+			]
+		},
+		{
+			"book": "D&C 76-100",
+			"chapters": [{
+					"chapter": 76,
+					"reference": "D&C 76",
+					"verses": [{
+							"reference": "D&C 76:1",
+							"text": "Hear, O ye heavens, and give ear, O earth, and rejoice ye inhabitants thereof, for the Lord is God, and beside him there is no Savior.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 76:2",
+							"text": "Great is his wisdom, marvelous are his ways, and the extent of his doings none can find out.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 76:3",
+							"text": "His purposes fail not, neither are there any who can stay his hand.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 76:4",
+							"text": "From eternity to eternity he is the same, and his years never fail.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 76:5",
+							"text": "For thus saith the Lord\u2014I, the Lord, am merciful and gracious unto those who fear me, and delight to honor those who serve me in righteousness and in truth unto the end.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 76:6",
+							"text": "Great shall be their reward and eternal shall be their glory.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 76:7",
+							"text": "And to them will I reveal all mysteries, yea, all the hidden mysteries of my kingdom from days of old, and for ages to come, will I make known unto them the good pleasure of my will concerning all things pertaining to my kingdom.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 76:8",
+							"text": "Yea, even the wonders of eternity shall they know, and things to come will I show them, even the things of many generations.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 76:9",
+							"text": "And their wisdom shall be great, and their understanding reach to heaven; and before them the wisdom of the wise shall perish, and the understanding of the prudent shall come to naught.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 76:10",
+							"text": "For by my Spirit will I enlighten them, and by my power will I make known unto them the secrets of my will\u2014yea, even those things which eye has not seen, nor ear heard, nor yet entered into the heart of man.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 76:11",
+							"text": "We, Joseph Smith, Jun., and Sidney Rigdon, being in the Spirit on the sixteenth day of February, in the year of our Lord one thousand eight hundred and thirty-two\u2014",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 76:12",
+							"text": "By the power of the Spirit our eyes were opened and our understandings were enlightened, so as to see and understand the things of God\u2014",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 76:13",
+							"text": "Even those things which were from the beginning before the world was, which were ordained of the Father, through his Only Begotten Son, who was in the bosom of the Father, even from the beginning;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 76:14",
+							"text": "Of whom we bear record; and the record which we bear is the fulness of the gospel of Jesus Christ, who is the Son, whom we saw and with whom we conversed in the heavenly vision.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 76:15",
+							"text": "For while we were doing the work of translation, which the Lord had appointed unto us, we came to the twenty-ninth verse of the fifth chapter of John, which was given unto us as follows\u2014",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 76:16",
+							"text": "Speaking of the resurrection of the dead, concerning those who shall hear the voice of the Son of Man:",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 76:17",
+							"text": "And shall come forth; they who have done good, in the resurrection of the just; and they who have done evil, in the resurrection of the unjust.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 76:18",
+							"text": "Now this caused us to marvel, for it was given unto us of the Spirit.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 76:19",
+							"text": "And while we meditated upon these things, the Lord touched the eyes of our understandings and they were opened, and the glory of the Lord shone round about.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 76:20",
+							"text": "And we beheld the glory of the Son, on the right hand of the Father, and received of his fulness;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 76:21",
+							"text": "And saw the holy angels, and them who are sanctified before his throne, worshiping God, and the Lamb, who worship him forever and ever.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 76:22",
+							"text": "And now, after the many testimonies which have been given of him, this is the testimony, last of all, which we give of him: That he lives!",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 76:23",
+							"text": "For we saw him, even on the right hand of God; and we heard the voice bearing record that he is the Only Begotten of the Father\u2014",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 76:24",
+							"text": "That by him, and through him, and of him, the worlds are and were created, and the inhabitants thereof are begotten sons and daughters unto God.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 76:25",
+							"text": "And this we saw also, and bear record, that an angel of God who was in authority in the presence of God, who rebelled against the Only Begotten Son whom the Father loved and who was in the bosom of the Father, was thrust down from the presence of God and the Son,",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 76:26",
+							"text": "And was called Perdition, for the heavens wept over him\u2014he was Lucifer, a son of the morning.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 76:27",
+							"text": "And we beheld, and lo, he is fallen! is fallen, even a son of the morning!",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 76:28",
+							"text": "And while we were yet in the Spirit, the Lord commanded us that we should write the vision; for we beheld Satan, that old serpent, even the devil, who rebelled against God, and sought to take the kingdom of our God and his Christ\u2014",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 76:29",
+							"text": "Wherefore, he maketh war with the saints of God, and encompasseth them round about.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 76:30",
+							"text": "And we saw a vision of the sufferings of those with whom he made war and overcame, for thus came the voice of the Lord unto us:",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 76:31",
+							"text": "Thus saith the Lord concerning all those who know my power, and have been made partakers thereof, and suffered themselves through the power of the devil to be overcome, and to deny the truth and defy my power\u2014",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 76:32",
+							"text": "They are they who are the sons of perdition, of whom I say that it had been better for them never to have been born;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 76:33",
+							"text": "For they are vessels of wrath, doomed to suffer the wrath of God, with the devil and his angels in eternity;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 76:34",
+							"text": "Concerning whom I have said there is no forgiveness in this world nor in the world to come\u2014",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 76:35",
+							"text": "Having denied the Holy Spirit after having received it, and having denied the Only Begotten Son of the Father, having crucified him unto themselves and put him to an open shame.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 76:36",
+							"text": "These are they who shall go away into the lake of fire and brimstone, with the devil and his angels\u2014",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 76:37",
+							"text": "And the only ones on whom the second death shall have any power;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 76:38",
+							"text": "Yea, verily, the only ones who shall not be redeemed in the due time of the Lord, after the sufferings of his wrath.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 76:39",
+							"text": "For all the rest shall be brought forth by the resurrection of the dead, through the triumph and the glory of the Lamb, who was slain, who was in the bosom of the Father before the worlds were made.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 76:40",
+							"text": "And this is the gospel, the glad tidings, which the voice out of the heavens bore record unto us\u2014",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 76:41",
+							"text": "That he came into the world, even Jesus, to be crucified for the world, and to bear the sins of the world, and to sanctify the world, and to cleanse it from all unrighteousness;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 76:42",
+							"text": "That through him all might be saved whom the Father had put into his power and made by him;",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 76:43",
+							"text": "Who glorifies the Father, and saves all the works of his hands, except those sons of perdition who deny the Son after the Father has revealed him.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 76:44",
+							"text": "Wherefore, he saves all except them\u2014they shall go away into everlasting punishment, which is endless punishment, which is eternal punishment, to reign with the devil and his angels in eternity, where their worm dieth not, and the fire is not quenched, which is their torment\u2014",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 76:45",
+							"text": "And the end thereof, neither the place thereof, nor their torment, no man knows;",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 76:46",
+							"text": "Neither was it revealed, neither is, neither will be revealed unto man, except to them who are made partakers thereof;",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 76:47",
+							"text": "Nevertheless, I, the Lord, show it by vision unto many, but straightway shut it up again;",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 76:48",
+							"text": "Wherefore, the end, the width, the height, the depth, and the misery thereof, they understand not, neither any man except those who are ordained unto this condemnation.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 76:49",
+							"text": "And we heard the voice, saying: Write the vision, for lo, this is the end of the vision of the sufferings of the ungodly.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 76:50",
+							"text": "And again we bear record\u2014for we saw and heard, and this is the testimony of the gospel of Christ concerning them who shall come forth in the resurrection of the just\u2014",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 76:51",
+							"text": "They are they who received the testimony of Jesus, and believed on his name and were baptized after the manner of his burial, being buried in the water in his name, and this according to the commandment which he has given\u2014",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 76:52",
+							"text": "That by keeping the commandments they might be washed and cleansed from all their sins, and receive the Holy Spirit by the laying on of the hands of him who is ordained and sealed unto this power;",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 76:53",
+							"text": "And who overcome by faith, and are sealed by the Holy Spirit of promise, which the Father sheds forth upon all those who are just and true.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 76:54",
+							"text": "They are they who are the church of the Firstborn.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 76:55",
+							"text": "They are they into whose hands the Father has given all things\u2014",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 76:56",
+							"text": "They are they who are priests and kings, who have received of his fulness, and of his glory;",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 76:57",
+							"text": "And are priests of the Most High, after the order of Melchizedek, which was after the order of Enoch, which was after the order of the Only Begotten Son.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 76:58",
+							"text": "Wherefore, as it is written, they are gods, even the sons of God\u2014",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 76:59",
+							"text": "Wherefore, all things are theirs, whether life or death, or things present, or things to come, all are theirs and they are Christ's, and Christ is God's.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 76:60",
+							"text": "And they shall overcome all things.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 76:61",
+							"text": "Wherefore, let no man glory in man, but rather let him glory in God, who shall subdue all enemies under his feet.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 76:62",
+							"text": "These shall dwell in the presence of God and his Christ forever and ever.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 76:63",
+							"text": "These are they whom he shall bring with him, when he shall come in the clouds of heaven to reign on the earth over his people.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 76:64",
+							"text": "These are they who shall have part in the first resurrection.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 76:65",
+							"text": "These are they who shall come forth in the resurrection of the just.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 76:66",
+							"text": "These are they who are come unto Mount Zion, and unto the city of the living God, the heavenly place, the holiest of all.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 76:67",
+							"text": "These are they who have come to an innumerable company of angels, to the general assembly and church of Enoch, and of the Firstborn.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 76:68",
+							"text": "These are they whose names are written in heaven, where God and Christ are the judge of all.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 76:69",
+							"text": "These are they who are just men made perfect through Jesus the mediator of the new covenant, who wrought out this perfect atonement through the shedding of his own blood.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 76:70",
+							"text": "These are they whose bodies are celestial, whose glory is that of the sun, even the glory of God, the highest of all, whose glory the sun of the firmament is written of as being typical.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 76:71",
+							"text": "And again, we saw the terrestrial world, and behold and lo, these are they who are of the terrestrial, whose glory differs from that of the church of the Firstborn who have received the fulness of the Father, even as that of the moon differs from the sun in the firmament.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 76:72",
+							"text": "Behold, these are they who died without law;",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 76:73",
+							"text": "And also they who are the spirits of men kept in prison, whom the Son visited, and preached the gospel unto them, that they might be judged according to men in the flesh;",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 76:74",
+							"text": "Who received not the testimony of Jesus in the flesh, but afterwards received it.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 76:75",
+							"text": "These are they who are honorable men of the earth, who were blinded by the craftiness of men.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 76:76",
+							"text": "These are they who receive of his glory, but not of his fulness.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 76:77",
+							"text": "These are they who receive of the presence of the Son, but not of the fulness of the Father.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 76:78",
+							"text": "Wherefore, they are bodies terrestrial, and not bodies celestial, and differ in glory as the moon differs from the sun.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 76:79",
+							"text": "These are they who are not valiant in the testimony of Jesus; wherefore, they obtain not the crown over the kingdom of our God.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 76:80",
+							"text": "And now this is the end of the vision which we saw of the terrestrial, that the Lord commanded us to write while we were yet in the Spirit.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 76:81",
+							"text": "And again, we saw the glory of the telestial, which glory is that of the lesser, even as the glory of the stars differs from that of the glory of the moon in the firmament.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 76:82",
+							"text": "These are they who received not the gospel of Christ, neither the testimony of Jesus.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 76:83",
+							"text": "These are they who deny not the Holy Spirit.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 76:84",
+							"text": "These are they who are thrust down to hell.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 76:85",
+							"text": "These are they who shall not be redeemed from the devil until the last resurrection, until the Lord, even Christ the Lamb, shall have finished his work.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 76:86",
+							"text": "These are they who receive not of his fulness in the eternal world, but of the Holy Spirit through the ministration of the terrestrial;",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 76:87",
+							"text": "And the terrestrial through the ministration of the celestial.",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 76:88",
+							"text": "And also the telestial receive it of the administering of angels who are appointed to minister for them, or who are appointed to be ministering spirits for them; for they shall be heirs of salvation.",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 76:89",
+							"text": "And thus we saw, in the heavenly vision, the glory of the telestial, which surpasses all understanding;",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 76:90",
+							"text": "And no man knows it except him to whom God has revealed it.",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 76:91",
+							"text": "And thus we saw the glory of the terrestrial which excels in all things the glory of the telestial, even in glory, and in power, and in might, and in dominion.",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 76:92",
+							"text": "And thus we saw the glory of the celestial, which excels in all things\u2014where God, even the Father, reigns upon his throne forever and ever;",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 76:93",
+							"text": "Before whose throne all things bow in humble reverence, and give him glory forever and ever.",
+							"verse": 93
+						},
+						{
+							"reference": "D&C 76:94",
+							"text": "They who dwell in his presence are the church of the Firstborn; and they see as they are seen, and know as they are known, having received of his fulness and of his grace;",
+							"verse": 94
+						},
+						{
+							"reference": "D&C 76:95",
+							"text": "And he makes them equal in power, and in might, and in dominion.",
+							"verse": 95
+						},
+						{
+							"reference": "D&C 76:96",
+							"text": "And the glory of the celestial is one, even as the glory of the sun is one.",
+							"verse": 96
+						},
+						{
+							"reference": "D&C 76:97",
+							"text": "And the glory of the terrestrial is one, even as the glory of the moon is one.",
+							"verse": 97
+						},
+						{
+							"reference": "D&C 76:98",
+							"text": "And the glory of the telestial is one, even as the glory of the stars is one; for as one star differs from another star in glory, even so differs one from another in glory in the telestial world;",
+							"verse": 98
+						},
+						{
+							"reference": "D&C 76:99",
+							"text": "For these are they who are of Paul, and of Apollos, and of Cephas.",
+							"verse": 99
+						},
+						{
+							"reference": "D&C 76:100",
+							"text": "These are they who say they are some of one and some of another\u2014some of Christ and some of John, and some of Moses, and some of Elias, and some of Esaias, and some of Isaiah, and some of Enoch;",
+							"verse": 100
+						},
+						{
+							"reference": "D&C 76:101",
+							"text": "But received not the gospel, neither the testimony of Jesus, neither the prophets, neither the everlasting covenant.",
+							"verse": 101
+						},
+						{
+							"reference": "D&C 76:102",
+							"text": "Last of all, these all are they who will not be gathered with the saints, to be caught up unto the church of the Firstborn, and received into the cloud.",
+							"verse": 102
+						},
+						{
+							"reference": "D&C 76:103",
+							"text": "These are they who are liars, and sorcerers, and adulterers, and whoremongers, and whosoever loves and makes a lie.",
+							"verse": 103
+						},
+						{
+							"reference": "D&C 76:104",
+							"text": "These are they who suffer the wrath of God on earth.",
+							"verse": 104
+						},
+						{
+							"reference": "D&C 76:105",
+							"text": "These are they who suffer the vengeance of eternal fire.",
+							"verse": 105
+						},
+						{
+							"reference": "D&C 76:106",
+							"text": "These are they who are cast down to hell and suffer the wrath of Almighty God, until the fulness of times, when Christ shall have subdued all enemies under his feet, and shall have perfected his work;",
+							"verse": 106
+						},
+						{
+							"reference": "D&C 76:107",
+							"text": "When he shall deliver up the kingdom, and present it unto the Father, spotless, saying: I have overcome and have trodden the wine-press alone, even the wine-press of the fierceness of the wrath of Almighty God.",
+							"verse": 107
+						},
+						{
+							"reference": "D&C 76:108",
+							"text": "Then shall he be crowned with the crown of his glory, to sit on the throne of his power to reign forever and ever.",
+							"verse": 108
+						},
+						{
+							"reference": "D&C 76:109",
+							"text": "But behold, and lo, we saw the glory and the inhabitants of the telestial world, that they were as innumerable as the stars in the firmament of heaven, or as the sand upon the seashore;",
+							"verse": 109
+						},
+						{
+							"reference": "D&C 76:110",
+							"text": "And heard the voice of the Lord saying: These all shall bow the knee, and every tongue shall confess to him who sits upon the throne forever and ever;",
+							"verse": 110
+						},
+						{
+							"reference": "D&C 76:111",
+							"text": "For they shall be judged according to their works, and every man shall receive according to his own works, his own dominion, in the mansions which are prepared;",
+							"verse": 111
+						},
+						{
+							"reference": "D&C 76:112",
+							"text": "And they shall be servants of the Most High; but where God and Christ dwell they cannot come, worlds without end.",
+							"verse": 112
+						},
+						{
+							"reference": "D&C 76:113",
+							"text": "This is the end of the vision which we saw, which we were commanded to write while we were yet in the Spirit.",
+							"verse": 113
+						},
+						{
+							"reference": "D&C 76:114",
+							"text": "But great and marvelous are the works of the Lord, and the mysteries of his kingdom which he showed unto us, which surpass all understanding in glory, and in might, and in dominion;",
+							"verse": 114
+						},
+						{
+							"reference": "D&C 76:115",
+							"text": "Which he commanded us we should not write while we were yet in the Spirit, and are not lawful for man to utter;",
+							"verse": 115
+						},
+						{
+							"reference": "D&C 76:116",
+							"text": "Neither is man capable to make them known, for they are only to be seen and understood by the power of the Holy Spirit, which God bestows on those who love him, and purify themselves before him;",
+							"verse": 116
+						},
+						{
+							"reference": "D&C 76:117",
+							"text": "To whom he grants this privilege of seeing and knowing for themselves;",
+							"verse": 117
+						},
+						{
+							"reference": "D&C 76:118",
+							"text": "That through the power and manifestation of the Spirit, while in the flesh, they may be able to bear his presence in the world of glory.",
+							"verse": 118
+						},
+						{
+							"reference": "D&C 76:119",
+							"text": "And to God and the Lamb be glory, and honor, and dominion forever and ever. Amen.",
+							"verse": 119
+						}
+					]
+				},
+				{
+					"chapter": 77,
+					"reference": "D&C 77",
+					"verses": [{
+							"reference": "D&C 77:1",
+							"text": "Q. What is the sea of glass spoken of by John, 4th chapter, and 6th verse of the Revelation? A. It is the earth, in its sanctified, immortal, and eternal state.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 77:2",
+							"text": "Q. What are we to understand by the four beasts, spoken of in the same verse? A. They are figurative expressions, used by the Revelator, John, in describing heaven, the paradise of God, the happiness of man, and of beasts, and of creeping things, and of the fowls of the air; that which is spiritual being in the likeness of that which is temporal; and that which is temporal in the likeness of that which is spiritual; the spirit of man in the likeness of his person, as also the spirit of the beast, and every other creature which God has created.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 77:3",
+							"text": "Q. Are the four beasts limited to individual beasts, or do they represent classes or orders? A. They are limited to four individual beasts, which were shown to John, to represent the glory of the classes of beings in their destined order or sphere of creation, in the enjoyment of their eternal felicity.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 77:4",
+							"text": "Q. What are we to understand by the eyes and wings, which the beasts had? A. Their eyes are a representation of light and knowledge, that is, they are full of knowledge; and their wings are a representation of power, to move, to act, etc.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 77:5",
+							"text": "Q. What are we to understand by the four and twenty elders, spoken of by John? A. We are to understand that these elders whom John saw, were elders who had been faithful in the work of the ministry and were dead; who belonged to the seven churches, and were then in the paradise of God.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 77:6",
+							"text": "Q. What are we to understand by the book which John saw, which was sealed on the back with seven seals? A. We are to understand that it contains the revealed will, mysteries, and the works of God; the hidden things of his economy concerning this earth during the seven thousand years of its continuance, or its temporal existence.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 77:7",
+							"text": "Q. What are we to understand by the seven seals with which it was sealed? A. We are to understand that the first seal contains the things of the first thousand years, and the second also of the second thousand years, and so on until the seventh.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 77:8",
+							"text": "Q. What are we to understand by the four angels, spoken of in the 7th chapter and 1st verse of Revelation? A. We are to understand that they are four angels sent forth from God, to whom is given power over the four parts of the earth, to save life and to destroy; these are they who have the everlasting gospel to commit to every nation, kindred, tongue, and people; having power to shut up the heavens, to seal up unto life, or to cast down to the regions of darkness.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 77:9",
+							"text": "Q. What are we to understand by the angel ascending from the east, Revelation 7th chapter and 2nd verse? A. We are to understand that the angel ascending from the east is he to whom is given the seal of the living God over the twelve tribes of Israel; wherefore, he crieth unto the four angels having the everlasting gospel, saying: Hurt not the earth, neither the sea, nor the trees, till we have sealed the servants of our God in their foreheads. And, if you will receive it, this is Elias which was to come to gather together the tribes of Israel and restore all things.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 77:10",
+							"text": "Q. What time are the things spoken of in this chapter to be accomplished? A. They are to be accomplished in the sixth thousand years, or the opening of the sixth seal.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 77:11",
+							"text": "Q. What are we to understand by sealing the one hundred and forty-four thousand, out of all the tribes of Israel\u2014twelve thousand out of every tribe? A. We are to understand that those who are sealed are high priests, ordained unto the holy order of God, to administer the everlasting gospel; for they are they who are ordained out of every nation, kindred, tongue, and people, by the angels to whom is given power over the nations of the earth, to bring as many as will come to the church of the Firstborn.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 77:12",
+							"text": "Q. What are we to understand by the sounding of the trumpets, mentioned in the 8th chapter of Revelation? A. We are to understand that as God made the world in six days, and on the seventh day he finished his work, and sanctified it, and also formed man out of the dust of the earth, even so, in the beginning of the seventh thousand years will the Lord God sanctify the earth, and complete the salvation of man, and judge all things, and shall redeem all things, except that which he hath not put into his power, when he shall have sealed all things, unto the end of all things; and the sounding of the trumpets of the seven angels are the preparing and finishing of his work, in the beginning of the seventh thousand years\u2014the preparing of the way before the time of his coming.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 77:13",
+							"text": "Q. When are the things to be accomplished, which are written in the 9th chapter of Revelation? A. They are to be accomplished after the opening of the seventh seal, before the coming of Christ.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 77:14",
+							"text": "Q. What are we to understand by the little book which was eaten by John, as mentioned in the 10th chapter of Revelation? A. We are to understand that it was a mission, and an ordinance, for him to gather the tribes of Israel; behold, this is Elias, who, as it is written, must come and restore all things.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 77:15",
+							"text": "Q. What is to be understood by the two witnesses, in the eleventh chapter of Revelation? A. They are two prophets that are to be raised up to the Jewish nation in the last days, at the time of the restoration, and to prophesy to the Jews after they are gathered and have built the city of Jerusalem in the land of their fathers.",
+							"verse": 15
+						}
+					]
+				},
+				{
+					"chapter": 78,
+					"reference": "D&C 78",
+					"verses": [{
+							"reference": "D&C 78:1",
+							"text": "The Lord spake unto Joseph Smith, Jun., saying: Hearken unto me, saith the Lord your God, who are ordained unto the high priesthood of my church, who have assembled yourselves together;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 78:2",
+							"text": "And listen to the counsel of him who has ordained you from on high, who shall speak in your ears the words of wisdom, that salvation may be unto you in that thing which you have presented before me, saith the Lord God.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 78:3",
+							"text": "For verily I say unto you, the time has come, and is now at hand; and behold, and lo, it must needs be that there be an organization of my people, in regulating and establishing the affairs of the storehouse for the poor of my people, both in this place and in the land of Zion\u2014",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 78:4",
+							"text": "For a permanent and everlasting establishment and order unto my church, to advance the cause, which ye have espoused, to the salvation of man, and to the glory of your Father who is in heaven;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 78:5",
+							"text": "That you may be equal in the bonds of heavenly things, yea, and earthly things also, for the obtaining of heavenly things.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 78:6",
+							"text": "For if ye are not equal in earthly things ye cannot be equal in obtaining heavenly things;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 78:7",
+							"text": "For if you will that I give unto you a place in the celestial world, you must prepare yourselves by doing the things which I have commanded you and required of you.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 78:8",
+							"text": "And now, verily thus saith the Lord, it is expedient that all things be done unto my glory, by you who are joined together in this order;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 78:9",
+							"text": "Or, in other words, let my servant Newel K. Whitney and my servant Joseph Smith, Jun., and my servant Sidney Rigdon sit in council with the saints which are in Zion;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 78:10",
+							"text": "Otherwise Satan seeketh to turn their hearts away from the truth, that they become blinded and understand not the things which are prepared for them.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 78:11",
+							"text": "Wherefore, a commandment I give unto you, to prepare and organize yourselves by a bond or everlasting covenant that cannot be broken.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 78:12",
+							"text": "And he who breaketh it shall lose his office and standing in the church, and shall be delivered over to the buffetings of Satan until the day of redemption.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 78:13",
+							"text": "Behold, this is the preparation wherewith I prepare you, and the foundation, and the ensample which I give unto you, whereby you may accomplish the commandments which are given you;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 78:14",
+							"text": "That through my providence, notwithstanding the tribulation which shall descend upon you, that the church may stand independent above all other creatures beneath the celestial world;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 78:15",
+							"text": "That you may come up unto the crown prepared for you, and be made rulers over many kingdoms, saith the Lord God, the Holy One of Zion, who hath established the foundations of Adam-ondi-Ahman;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 78:16",
+							"text": "Who hath appointed Michael your prince, and established his feet, and set him upon high, and given unto him the keys of salvation under the counsel and direction of the Holy One, who is without beginning of days or end of life.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 78:17",
+							"text": "Verily, verily, I say unto you, ye are little children, and ye have not as yet understood how great blessings the Father hath in his own hands and prepared for you;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 78:18",
+							"text": "And ye cannot bear all things now; nevertheless, be of good cheer, for I will lead you along. The kingdom is yours and the blessings thereof are yours, and the riches of eternity are yours.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 78:19",
+							"text": "And he who receiveth all things with thankfulness shall be made glorious; and the things of this earth shall be added unto him, even an hundred fold, yea, more.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 78:20",
+							"text": "Wherefore, do the things which I have commanded you, saith your Redeemer, even the Son Ahman, who prepareth all things before he taketh you;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 78:21",
+							"text": "For ye are the church of the Firstborn, and he will take you up in a cloud, and appoint every man his portion.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 78:22",
+							"text": "And he that is a faithful and wise steward shall inherit all things. Amen.",
+							"verse": 22
+						}
+					]
+				},
+				{
+					"chapter": 79,
+					"reference": "D&C 79",
+					"verses": [{
+							"reference": "D&C 79:1",
+							"text": "Verily I say unto you, that it is my will that my servant Jared Carter should go again into the eastern countries, from place to place, and from city to city, in the power of the ordination wherewith he has been ordained, proclaiming glad tidings of great joy, even the everlasting gospel.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 79:2",
+							"text": "And I will send upon him the Comforter, which shall teach him the truth and the way whither he shall go;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 79:3",
+							"text": "And inasmuch as he is faithful, I will crown him again with sheaves.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 79:4",
+							"text": "Wherefore, let your heart be glad, my servant Jared Carter, and fear not, saith your Lord, even Jesus Christ. Amen.",
+							"verse": 4
+						}
+					]
+				},
+				{
+					"chapter": 80,
+					"reference": "D&C 80",
+					"verses": [{
+							"reference": "D&C 80:1",
+							"text": "Verily, thus saith the Lord unto you my servant Stephen Burnett: Go ye, go ye into the world and preach the gospel to every creature that cometh under the sound of your voice.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 80:2",
+							"text": "And inasmuch as you desire a companion, I will give unto you my servant Eden Smith.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 80:3",
+							"text": "Wherefore, go ye and preach my gospel, whether to the north or to the south, to the east or to the west, it mattereth not, for ye cannot go amiss.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 80:4",
+							"text": "Therefore, declare the things which ye have heard, and verily believe, and know to be true.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 80:5",
+							"text": "Behold, this is the will of him who hath called you, your Redeemer, even Jesus Christ. Amen.",
+							"verse": 5
+						}
+					]
+				},
+				{
+					"chapter": 81,
+					"reference": "D&C 81",
+					"verses": [{
+							"reference": "D&C 81:1",
+							"text": "Verily, verily, I say unto you my servant Frederick G. Williams: Listen to the voice of him who speaketh, to the word of the Lord your God, and hearken to the calling wherewith you are called, even to be a high priest in my church, and a counselor unto my servant Joseph Smith, Jun.;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 81:2",
+							"text": "Unto whom I have given the keys of the kingdom, which belong always unto the Presidency of the High Priesthood:",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 81:3",
+							"text": "Therefore, verily I acknowledge him and will bless him, and also thee, inasmuch as thou art faithful in counsel, in the office which I have appointed unto you, in prayer always, vocally and in thy heart, in public and in private, also in thy ministry in proclaiming the gospel in the land of the living, and among thy brethren.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 81:4",
+							"text": "And in doing these things thou wilt do the greatest good unto thy fellow beings, and wilt promote the glory of him who is your Lord.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 81:5",
+							"text": "Wherefore, be faithful; stand in the office which I have appointed unto you; succor the weak, lift up the hands which hang down, and strengthen the feeble knees.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 81:6",
+							"text": "And if thou art faithful unto the end thou shalt have a crown of immortality, and eternal life in the mansions which I have prepared in the house of my Father.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 81:7",
+							"text": "Behold, and lo, these are the words of Alpha and Omega, even Jesus Christ. Amen.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 82,
+					"reference": "D&C 82",
+					"verses": [{
+							"reference": "D&C 82:1",
+							"text": "Verily, verily, I say unto you, my servants, that inasmuch as you have forgiven one another your trespasses, even so I, the Lord, forgive you.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 82:2",
+							"text": "Nevertheless, there are those among you who have sinned exceedingly; yea, even all of you have sinned; but verily I say unto you, beware from henceforth, and refrain from sin, lest sore judgments fall upon your heads.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 82:3",
+							"text": "For of him unto whom much is given much is required; and he who sins against the greater light shall receive the greater condemnation.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 82:4",
+							"text": "Ye call upon my name for revelations, and I give them unto you; and inasmuch as ye keep not my sayings, which I give unto you, ye become transgressors; and justice and judgment are the penalty which is affixed unto my law.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 82:5",
+							"text": "Therefore, what I say unto one I say unto all: Watch, for the adversary spreadeth his dominions, and darkness reigneth;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 82:6",
+							"text": "And the anger of God kindleth against the inhabitants of the earth; and none doeth good, for all have gone out of the way.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 82:7",
+							"text": "And now, verily I say unto you, I, the Lord, will not lay any sin to your charge; go your ways and sin no more; but unto that soul who sinneth shall the former sins return, saith the Lord your God.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 82:8",
+							"text": "And again, I say unto you, I give unto you a new commandment, that you may understand my will concerning you;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 82:9",
+							"text": "Or, in other words, I give unto you directions how you may act before me, that it may turn to you for your salvation.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 82:10",
+							"text": "I, the Lord, am bound when ye do what I say; but when ye do not what I say, ye have no promise.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 82:11",
+							"text": "Therefore, verily I say unto you, that it is expedient for my servants Edward Partridge and Newel K. Whitney, A. Sidney Gilbert and Sidney Rigdon, and my servant Joseph Smith, and John Whitmer and Oliver Cowdery, and W. W. Phelps and Martin Harris to be bound together by a bond and covenant that cannot be broken by transgression, except judgment shall immediately follow, in your several stewardships\u2014",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 82:12",
+							"text": "To manage the affairs of the poor, and all things pertaining to the bishopric both in the land of Zion and in the land of Kirtland;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 82:13",
+							"text": "For I have consecrated the land of Kirtland in mine own due time for the benefit of the saints of the Most High, and for a stake to Zion.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 82:14",
+							"text": "For Zion must increase in beauty, and in holiness; her borders must be enlarged; her stakes must be strengthened; yea, verily I say unto you, Zion must arise and put on her beautiful garments.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 82:15",
+							"text": "Therefore, I give unto you this commandment, that ye bind yourselves by this covenant, and it shall be done according to the laws of the Lord.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 82:16",
+							"text": "Behold, here is wisdom also in me for your good.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 82:17",
+							"text": "And you are to be equal, or in other words, you are to have equal claims on the properties, for the benefit of managing the concerns of your stewardships, every man according to his wants and his needs, inasmuch as his wants are just\u2014",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 82:18",
+							"text": "And all this for the benefit of the church of the living God, that every man may improve upon his talent, that every man may gain other talents, yea, even an hundred fold, to be cast into the Lord's storehouse, to become the common property of the whole church\u2014",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 82:19",
+							"text": "Every man seeking the interest of his neighbor, and doing all things with an eye single to the glory of God.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 82:20",
+							"text": "This order I have appointed to be an everlasting order unto you, and unto your successors, inasmuch as you sin not.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 82:21",
+							"text": "And the soul that sins against this covenant, and hardeneth his heart against it, shall be dealt with according to the laws of my church, and shall be delivered over to the buffetings of Satan until the day of redemption.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 82:22",
+							"text": "And now, verily I say unto you, and this is wisdom, make unto yourselves friends with the mammon of unrighteousness, and they will not destroy you.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 82:23",
+							"text": "Leave judgment alone with me, for it is mine and I will repay. Peace be with you; my blessings continue with you.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 82:24",
+							"text": "For even yet the kingdom is yours, and shall be forever, if you fall not from your steadfastness. Even so. Amen.",
+							"verse": 24
+						}
+					]
+				},
+				{
+					"chapter": 83,
+					"reference": "D&C 83",
+					"verses": [{
+							"reference": "D&C 83:1",
+							"text": "Verily, thus saith the Lord, in addition to the laws of the church concerning women and children, those who belong to the church, who have lost their husbands or fathers:",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 83:2",
+							"text": "Women have claim on their husbands for their maintenance, until their husbands are taken; and if they are not found transgressors they shall have fellowship in the church.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 83:3",
+							"text": "And if they are not faithful they shall not have fellowship in the church; yet they may remain upon their inheritances according to the laws of the land.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 83:4",
+							"text": "All children have claim upon their parents for their maintenance until they are of age.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 83:5",
+							"text": "And after that, they have claim upon the church, or in other words upon the Lord's storehouse, if their parents have not wherewith to give them inheritances.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 83:6",
+							"text": "And the storehouse shall be kept by the consecrations of the church; and widows and orphans shall be provided for, as also the poor. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 84,
+					"reference": "D&C 84",
+					"verses": [{
+							"reference": "D&C 84:1",
+							"text": "A revelation of Jesus Christ unto his servant Joseph Smith, Jun., and six elders, as they united their hearts and lifted their voices on high.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 84:2",
+							"text": "Yea, the word of the Lord concerning his church, established in the last days for the restoration of his people, as he has spoken by the mouth of his prophets, and for the gathering of his saints to stand upon Mount Zion, which shall be the city of New Jerusalem.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 84:3",
+							"text": "Which city shall be built, beginning at the temple lot, which is appointed by the finger of the Lord, in the western boundaries of the State of Missouri, and dedicated by the hand of Joseph Smith, Jun., and others with whom the Lord was well pleased.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 84:4",
+							"text": "Verily this is the word of the Lord, that the city New Jerusalem shall be built by the gathering of the saints, beginning at this place, even the place of the temple, which temple shall be reared in this generation.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 84:5",
+							"text": "For verily this generation shall not all pass away until an house shall be built unto the Lord, and a cloud shall rest upon it, which cloud shall be even the glory of the Lord, which shall fill the house.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 84:6",
+							"text": "And the sons of Moses, according to the Holy Priesthood which he received under the hand of his father-in-law, Jethro;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 84:7",
+							"text": "And Jethro received it under the hand of Caleb;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 84:8",
+							"text": "And Caleb received it under the hand of Elihu;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 84:9",
+							"text": "And Elihu under the hand of Jeremy;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 84:10",
+							"text": "And Jeremy under the hand of Gad;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 84:11",
+							"text": "And Gad under the hand of Esaias;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 84:12",
+							"text": "And Esaias received it under the hand of God.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 84:13",
+							"text": "Esaias also lived in the days of Abraham, and was blessed of him\u2014",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 84:14",
+							"text": "Which Abraham received the priesthood from Melchizedek, who received it through the lineage of his fathers, even till Noah;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 84:15",
+							"text": "And from Noah till Enoch, through the lineage of their fathers;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 84:16",
+							"text": "And from Enoch to Abel, who was slain by the conspiracy of his brother, who received the priesthood by the commandments of God, by the hand of his father Adam, who was the first man\u2014",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 84:17",
+							"text": "Which priesthood continueth in the church of God in all generations, and is without beginning of days or end of years.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 84:18",
+							"text": "And the Lord confirmed a priesthood also upon Aaron and his seed, throughout all their generations, which priesthood also continueth and abideth forever with the priesthood which is after the holiest order of God.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 84:19",
+							"text": "And this greater priesthood administereth the gospel and holdeth the key of the mysteries of the kingdom, even the key of the knowledge of God.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 84:20",
+							"text": "Therefore, in the ordinances thereof, the power of godliness is manifest.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 84:21",
+							"text": "And without the ordinances thereof, and the authority of the priesthood, the power of godliness is not manifest unto men in the flesh;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 84:22",
+							"text": "For without this no man can see the face of God, even the Father, and live.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 84:23",
+							"text": "Now this Moses plainly taught to the children of Israel in the wilderness, and sought diligently to sanctify his people that they might behold the face of God;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 84:24",
+							"text": "But they hardened their hearts and could not endure his presence; therefore, the Lord in his wrath, for his anger was kindled against them, swore that they should not enter into his rest while in the wilderness, which rest is the fulness of his glory.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 84:25",
+							"text": "Therefore, he took Moses out of their midst, and the Holy Priesthood also;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 84:26",
+							"text": "And the lesser priesthood continued, which priesthood holdeth the key of the ministering of angels and the preparatory gospel;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 84:27",
+							"text": "Which gospel is the gospel of repentance and of baptism, and the remission of sins, and the law of carnal commandments, which the Lord in his wrath caused to continue with the house of Aaron among the children of Israel until John, whom God raised up, being filled with the Holy Ghost from his mother's womb.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 84:28",
+							"text": "For he was baptized while he was yet in his childhood, and was ordained by the angel of God at the time he was eight days old unto this power, to overthrow the kingdom of the Jews, and to make straight the way of the Lord before the face of his people, to prepare them for the coming of the Lord, in whose hand is given all power.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 84:29",
+							"text": "And again, the offices of elder and bishop are necessary appendages belonging unto the high priesthood.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 84:30",
+							"text": "And again, the offices of teacher and deacon are necessary appendages belonging to the lesser priesthood, which priesthood was confirmed upon Aaron and his sons.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 84:31",
+							"text": "Therefore, as I said concerning the sons of Moses\u2014for the sons of Moses and also the sons of Aaron shall offer an acceptable offering and sacrifice in the house of the Lord, which house shall be built unto the Lord in this generation, upon the consecrated spot as I have appointed\u2014",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 84:32",
+							"text": "And the sons of Moses and of Aaron shall be filled with the glory of the Lord, upon Mount Zion in the Lord's house, whose sons are ye; and also many whom I have called and sent forth to build up my church.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 84:33",
+							"text": "For whoso is faithful unto the obtaining these two priesthoods of which I have spoken, and the magnifying their calling, are sanctified by the Spirit unto the renewing of their bodies.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 84:34",
+							"text": "They become the sons of Moses and of Aaron and the seed of Abraham, and the church and kingdom, and the elect of God.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 84:35",
+							"text": "And also all they who receive this priesthood receive me, saith the Lord;",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 84:36",
+							"text": "For he that receiveth my servants receiveth me;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 84:37",
+							"text": "And he that receiveth me receiveth my Father;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 84:38",
+							"text": "And he that receiveth my Father receiveth my Father's kingdom; therefore all that my Father hath shall be given unto him.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 84:39",
+							"text": "And this is according to the oath and covenant which belongeth to the priesthood.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 84:40",
+							"text": "Therefore, all those who receive the priesthood, receive this oath and covenant of my Father, which he cannot break, neither can it be moved.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 84:41",
+							"text": "But whoso breaketh this covenant after he hath received it, and altogether turneth therefrom, shall not have forgiveness of sins in this world nor in the world to come.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 84:42",
+							"text": "And wo unto all those who come not unto this priesthood which ye have received, which I now confirm upon you who are present this day, by mine own voice out of the heavens; and even I have given the heavenly hosts and mine angels charge concerning you.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 84:43",
+							"text": "And I now give unto you a commandment to beware concerning yourselves, to give diligent heed to the words of eternal life.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 84:44",
+							"text": "For you shall live by every word that proceedeth forth from the mouth of God.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 84:45",
+							"text": "For the word of the Lord is truth, and whatsoever is truth is light, and whatsoever is light is Spirit, even the Spirit of Jesus Christ.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 84:46",
+							"text": "And the Spirit giveth light to every man that cometh into the world; and the Spirit enlighteneth every man through the world, that hearkeneth to the voice of the Spirit.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 84:47",
+							"text": "And every one that hearkeneth to the voice of the Spirit cometh unto God, even the Father.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 84:48",
+							"text": "And the Father teacheth him of the covenant which he has renewed and confirmed upon you, which is confirmed upon you for your sakes, and not for your sakes only, but for the sake of the whole world.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 84:49",
+							"text": "And the whole world lieth in sin, and groaneth under darkness and under the bondage of sin.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 84:50",
+							"text": "And by this you may know they are under the bondage of sin, because they come not unto me.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 84:51",
+							"text": "For whoso cometh not unto me is under the bondage of sin.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 84:52",
+							"text": "And whoso receiveth not my voice is not acquainted with my voice, and is not of me.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 84:53",
+							"text": "And by this you may know the righteous from the wicked, and that the whole world groaneth under sin and darkness even now.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 84:54",
+							"text": "And your minds in times past have been darkened because of unbelief, and because you have treated lightly the things you have received\u2014",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 84:55",
+							"text": "Which vanity and unbelief have brought the whole church under condemnation.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 84:56",
+							"text": "And this condemnation resteth upon the children of Zion, even all.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 84:57",
+							"text": "And they shall remain under this condemnation until they repent and remember the new covenant, even the Book of Mormon and the former commandments which I have given them, not only to say, but to do according to that which I have written\u2014",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 84:58",
+							"text": "That they may bring forth fruit meet for their Father's kingdom; otherwise there remaineth a scourge and judgment to be poured out upon the children of Zion.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 84:59",
+							"text": "For shall the children of the kingdom pollute my holy land? Verily, I say unto you, Nay.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 84:60",
+							"text": "Verily, verily, I say unto you who now hear my words, which are my voice, blessed are ye inasmuch as you receive these things;",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 84:61",
+							"text": "For I will forgive you of your sins with this commandment\u2014that you remain steadfast in your minds in solemnity and the spirit of prayer, in bearing testimony to all the world of those things which are communicated unto you.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 84:62",
+							"text": "Therefore, go ye into all the world; and unto whatsoever place ye cannot go ye shall send, that the testimony may go from you into all the world unto every creature.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 84:63",
+							"text": "And as I said unto mine apostles, even so I say unto you, for you are mine apostles, even God's high priests; ye are they whom my Father hath given me; ye are my friends;",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 84:64",
+							"text": "Therefore, as I said unto mine apostles I say unto you again, that every soul who believeth on your words, and is baptized by water for the remission of sins, shall receive the Holy Ghost.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 84:65",
+							"text": "And these signs shall follow them that believe\u2014",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 84:66",
+							"text": "In my name they shall do many wonderful works;",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 84:67",
+							"text": "In my name they shall cast out devils;",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 84:68",
+							"text": "In my name they shall heal the sick;",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 84:69",
+							"text": "In my name they shall open the eyes of the blind, and unstop the ears of the deaf;",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 84:70",
+							"text": "And the tongue of the dumb shall speak;",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 84:71",
+							"text": "And if any man shall administer poison unto them it shall not hurt them;",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 84:72",
+							"text": "And the poison of a serpent shall not have power to harm them.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 84:73",
+							"text": "But a commandment I give unto them, that they shall not boast themselves of these things, neither speak them before the world; for these things are given unto you for your profit and for salvation.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 84:74",
+							"text": "Verily, verily, I say unto you, they who believe not on your words, and are not baptized in water in my name, for the remission of their sins, that they may receive the Holy Ghost, shall be damned, and shall not come into my Father's kingdom where my Father and I am.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 84:75",
+							"text": "And this revelation unto you, and commandment, is in force from this very hour upon all the world, and the gospel is unto all who have not received it.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 84:76",
+							"text": "But, verily I say unto all those to whom the kingdom has been given\u2014from you it must be preached unto them, that they shall repent of their former evil works; for they are to be upbraided for their evil hearts of unbelief, and your brethren in Zion for their rebellion against you at the time I sent you.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 84:77",
+							"text": "And again I say unto you, my friends, for from henceforth I shall call you friends, it is expedient that I give unto you this commandment, that ye become even as my friends in days when I was with them, traveling to preach the gospel in my power;",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 84:78",
+							"text": "For I suffered them not to have purse or scrip, neither two coats.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 84:79",
+							"text": "Behold, I send you out to prove the world, and the laborer is worthy of his hire.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 84:80",
+							"text": "And any man that shall go and preach this gospel of the kingdom, and fail not to continue faithful in all things, shall not be weary in mind, neither darkened, neither in body, limb, nor joint; and a hair of his head shall not fall to the ground unnoticed. And they shall not go hungry, neither athirst.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 84:81",
+							"text": "Therefore, take ye no thought for the morrow, for what ye shall eat, or what ye shall drink, or wherewithal ye shall be clothed.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 84:82",
+							"text": "For, consider the lilies of the field, how they grow, they toil not, neither do they spin; and the kingdoms of the world, in all their glory, are not arrayed like one of these.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 84:83",
+							"text": "For your Father, who is in heaven, knoweth that you have need of all these things.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 84:84",
+							"text": "Therefore, let the morrow take thought for the things of itself.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 84:85",
+							"text": "Neither take ye thought beforehand what ye shall say; but treasure up in your minds continually the words of life, and it shall be given you in the very hour that portion that shall be meted unto every man.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 84:86",
+							"text": "Therefore, let no man among you, for this commandment is unto all the faithful who are called of God in the church unto the ministry, from this hour take purse or scrip, that goeth forth to proclaim this gospel of the kingdom.",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 84:87",
+							"text": "Behold, I send you out to reprove the world of all their unrighteous deeds, and to teach them of a judgment which is to come.",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 84:88",
+							"text": "And whoso receiveth you, there I will be also, for I will go before your face. I will be on your right hand and on your left, and my Spirit shall be in your hearts, and mine angels round about you, to bear you up.",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 84:89",
+							"text": "Whoso receiveth you receiveth me; and the same will feed you, and clothe you, and give you money.",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 84:90",
+							"text": "And he who feeds you, or clothes you, or gives you money, shall in nowise lose his reward.",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 84:91",
+							"text": "And he that doeth not these things is not my disciple; by this you may know my disciples.",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 84:92",
+							"text": "He that receiveth you not, go away from him alone by yourselves, and cleanse your feet even with water, pure water, whether in heat or in cold, and bear testimony of it unto your Father which is in heaven, and return not again unto that man.",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 84:93",
+							"text": "And in whatsoever village or city ye enter, do likewise.",
+							"verse": 93
+						},
+						{
+							"reference": "D&C 84:94",
+							"text": "Nevertheless, search diligently and spare not; and wo unto that house, or that village or city that rejecteth you, or your words, or your testimony concerning me.",
+							"verse": 94
+						},
+						{
+							"reference": "D&C 84:95",
+							"text": "Wo, I say again, unto that house, or that village or city that rejecteth you, or your words, or your testimony of me;",
+							"verse": 95
+						},
+						{
+							"reference": "D&C 84:96",
+							"text": "For I, the Almighty, have laid my hands upon the nations, to scourge them for their wickedness.",
+							"verse": 96
+						},
+						{
+							"reference": "D&C 84:97",
+							"text": "And plagues shall go forth, and they shall not be taken from the earth until I have completed my work, which shall be cut short in righteousness\u2014",
+							"verse": 97
+						},
+						{
+							"reference": "D&C 84:98",
+							"text": "Until all shall know me, who remain, even from the least unto the greatest, and shall be filled with the knowledge of the Lord, and shall see eye to eye, and shall lift up their voice, and with the voice together sing this new song, saying:",
+							"verse": 98
+						},
+						{
+							"reference": "D&C 84:99",
+							"text": "The Lord hath brought again Zion;",
+							"verse": 99
+						},
+						{
+							"reference": "D&C 84:100",
+							"text": "The Lord hath redeemed his people;",
+							"verse": 100
+						},
+						{
+							"reference": "D&C 84:101",
+							"text": "The earth hath travailed and brought forth her strength;",
+							"verse": 101
+						},
+						{
+							"reference": "D&C 84:102",
+							"text": "Glory, and honor, and power, and might,",
+							"verse": 102
+						},
+						{
+							"reference": "D&C 84:103",
+							"text": "And again, verily, verily, I say unto you, it is expedient that every man who goes forth to proclaim mine everlasting gospel, that inasmuch as they have families, and receive money by gift, that they should send it unto them or make use of it for their benefit, as the Lord shall direct them, for thus it seemeth me good.",
+							"verse": 103
+						},
+						{
+							"reference": "D&C 84:104",
+							"text": "And let all those who have not families, who receive money, send it up unto the bishop in Zion, or unto the bishop in Ohio, that it may be consecrated for the bringing forth of the revelations and the printing thereof, and for establishing Zion.",
+							"verse": 104
+						},
+						{
+							"reference": "D&C 84:105",
+							"text": "And if any man shall give unto any of you a coat, or a suit, take the old and cast it unto the poor, and go on your way rejoicing.",
+							"verse": 105
+						},
+						{
+							"reference": "D&C 84:106",
+							"text": "And if any man among you be strong in the Spirit, let him take with him him that is weak, that he may be edified in all meekness, that he may become strong also.",
+							"verse": 106
+						},
+						{
+							"reference": "D&C 84:107",
+							"text": "Therefore, take with you those who are ordained unto the lesser priesthood, and send them before you to make appointments, and to prepare the way, and to fill appointments that you yourselves are not able to fill.",
+							"verse": 107
+						},
+						{
+							"reference": "D&C 84:108",
+							"text": "Behold, this is the way that mine apostles, in ancient days, built up my church unto me.",
+							"verse": 108
+						},
+						{
+							"reference": "D&C 84:109",
+							"text": "Therefore, let every man stand in his own office, and labor in his own calling; and let not the head say unto the feet it hath no need of the feet; for without the feet how shall the body be able to stand?",
+							"verse": 109
+						},
+						{
+							"reference": "D&C 84:110",
+							"text": "Also the body hath need of every member, that all may be edified together, that the system may be kept perfect.",
+							"verse": 110
+						},
+						{
+							"reference": "D&C 84:111",
+							"text": "And behold, the high priests should travel, and also the elders, and also the lesser priests; but the deacons and teachers should be appointed to watch over the church, to be standing ministers unto the church.",
+							"verse": 111
+						},
+						{
+							"reference": "D&C 84:112",
+							"text": "And the bishop, Newel K. Whitney, also should travel round about and among all the churches, searching after the poor to administer to their wants by humbling the rich and the proud.",
+							"verse": 112
+						},
+						{
+							"reference": "D&C 84:113",
+							"text": "He should also employ an agent to take charge and to do his secular business as he shall direct.",
+							"verse": 113
+						},
+						{
+							"reference": "D&C 84:114",
+							"text": "Nevertheless, let the bishop go unto the city of New York, also to the city of Albany, and also to the city of Boston, and warn the people of those cities with the sound of the gospel, with a loud voice, of the desolation and utter abolishment which await them if they do reject these things.",
+							"verse": 114
+						},
+						{
+							"reference": "D&C 84:115",
+							"text": "For if they do reject these things the hour of their judgment is nigh, and their house shall be left unto them desolate.",
+							"verse": 115
+						},
+						{
+							"reference": "D&C 84:116",
+							"text": "Let him trust in me and he shall not be confounded; and a hair of his head shall not fall to the ground unnoticed.",
+							"verse": 116
+						},
+						{
+							"reference": "D&C 84:117",
+							"text": "And verily I say unto you, the rest of my servants, go ye forth as your circumstances shall permit, in your several callings, unto the great and notable cities and villages, reproving the world in righteousness of all their unrighteous and ungodly deeds, setting forth clearly and understandingly the desolation of abomination in the last days.",
+							"verse": 117
+						},
+						{
+							"reference": "D&C 84:118",
+							"text": "For, with you saith the Lord Almighty, I will rend their kingdoms; I will not only shake the earth, but the starry heavens shall tremble.",
+							"verse": 118
+						},
+						{
+							"reference": "D&C 84:119",
+							"text": "For I, the Lord, have put forth my hand to exert the powers of heaven; ye cannot see it now, yet a little while and ye shall see it, and know that I am, and that I will come and reign with my people.",
+							"verse": 119
+						},
+						{
+							"reference": "D&C 84:120",
+							"text": "I am Alpha and Omega, the beginning and the end. Amen.",
+							"verse": 120
+						}
+					]
+				},
+				{
+					"chapter": 85,
+					"reference": "D&C 85",
+					"verses": [{
+							"reference": "D&C 85:1",
+							"text": "It is the duty of the Lord's clerk, whom he has appointed, to keep a history, and a general church record of all things that transpire in Zion, and of all those who consecrate properties, and receive inheritances legally from the bishop;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 85:2",
+							"text": "And also their manner of life, their faith, and works; and also of the apostates who apostatize after receiving their inheritances.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 85:3",
+							"text": "It is contrary to the will and commandment of God that those who receive not their inheritance by consecration, agreeable to his law, which he has given, that he may tithe his people, to prepare them against the day of vengeance and burning, should have their names enrolled with the people of God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 85:4",
+							"text": "Neither is their genealogy to be kept, or to be had where it may be found on any of the records or history of the church.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 85:5",
+							"text": "Their names shall not be found, neither the names of the fathers, nor the names of the children written in the book of the law of God, saith the Lord of Hosts.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 85:6",
+							"text": "Yea, thus saith the still small voice, which whispereth through and pierceth all things, and often times it maketh my bones to quake while it maketh manifest, saying:",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 85:7",
+							"text": "And it shall come to pass that I, the Lord God, will send one mighty and strong, holding the scepter of power in his hand, clothed with light for a covering, whose mouth shall utter words, eternal words; while his bowels shall be a fountain of truth, to set in order the house of God, and to arrange by lot the inheritances of the saints whose names are found, and the names of their fathers, and of their children, enrolled in the book of the law of God;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 85:8",
+							"text": "While that man, who was called of God and appointed, that putteth forth his hand to steady the ark of God, shall fall by the shaft of death, like as a tree that is smitten by the vivid shaft of lightning.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 85:9",
+							"text": "And all they who are not found written in the book of remembrance shall find none inheritance in that day, but they shall be cut asunder, and their portion shall be appointed them among unbelievers, where are wailing and gnashing of teeth.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 85:10",
+							"text": "These things I say not of myself; therefore, as the Lord speaketh, he will also fulfil.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 85:11",
+							"text": "And they who are of the High Priesthood, whose names are not found written in the book of the law, or that are found to have apostatized, or to have been cut off from the church, as well as the lesser priesthood, or the members, in that day shall not find an inheritance among the saints of the Most High;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 85:12",
+							"text": "Therefore, it shall be done unto them as unto the children of the priest, as will be found recorded in the second chapter and sixty-first and second verses of Ezra.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 86,
+					"reference": "D&C 86",
+					"verses": [{
+							"reference": "D&C 86:1",
+							"text": "Verily, thus saith the Lord unto you my servants, concerning the parable of the wheat and of the tares:",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 86:2",
+							"text": "Behold, verily I say, the field was the world, and the apostles were the sowers of the seed;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 86:3",
+							"text": "And after they have fallen asleep the great persecutor of the church, the apostate, the whore, even Babylon, that maketh all nations to drink of her cup, in whose hearts the enemy, even Satan, sitteth to reign\u2014behold he soweth the tares; wherefore, the tares choke the wheat and drive the church into the wilderness.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 86:4",
+							"text": "But behold, in the last days, even now while the Lord is beginning to bring forth the word, and the blade is springing up and is yet tender\u2014",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 86:5",
+							"text": "Behold, verily I say unto you, the angels are crying unto the Lord day and night, who are ready and waiting to be sent forth to reap down the fields;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 86:6",
+							"text": "But the Lord saith unto them, pluck not up the tares while the blade is yet tender (for verily your faith is weak), lest you destroy the wheat also.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 86:7",
+							"text": "Therefore, let the wheat and the tares grow together until the harvest is fully ripe; then ye shall first gather out the wheat from among the tares, and after the gathering of the wheat, behold and lo, the tares are bound in bundles, and the field remaineth to be burned.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 86:8",
+							"text": "Therefore, thus saith the Lord unto you, with whom the priesthood hath continued through the lineage of your fathers\u2014",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 86:9",
+							"text": "For ye are lawful heirs, according to the flesh, and have been hid from the world with Christ in God\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 86:10",
+							"text": "Therefore your life and the priesthood have remained, and must needs remain through you and your lineage until the restoration of all things spoken by the mouths of all the holy prophets since the world began.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 86:11",
+							"text": "Therefore, blessed are ye if ye continue in my goodness, a light unto the Gentiles, and through this priesthood, a savior unto my people Israel. The Lord hath said it. Amen.",
+							"verse": 11
+						}
+					]
+				},
+				{
+					"chapter": 87,
+					"reference": "D&C 87",
+					"verses": [{
+							"reference": "D&C 87:1",
+							"text": "Verily, thus saith the Lord concerning the wars that will shortly come to pass, beginning at the rebellion of South Carolina, which will eventually terminate in the death and misery of many souls;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 87:2",
+							"text": "And the time will come that war will be poured out upon all nations, beginning at this place.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 87:3",
+							"text": "For behold, the Southern States shall be divided against the Northern States, and the Southern States will call on other nations, even the nation of Great Britain, as it is called, and they shall also call upon other nations, in order to defend themselves against other nations; and then war shall be poured out upon all nations.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 87:4",
+							"text": "And it shall come to pass, after many days, slaves shall rise up against their masters, who shall be marshaled and disciplined for war.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 87:5",
+							"text": "And it shall come to pass also that the remnants who are left of the land will marshal themselves, and shall become exceedingly angry, and shall vex the Gentiles with a sore vexation.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 87:6",
+							"text": "And thus, with the sword and by bloodshed the inhabitants of the earth shall mourn; and with famine, and plague, and earthquake, and the thunder of heaven, and the fierce and vivid lightning also, shall the inhabitants of the earth be made to feel the wrath, and indignation, and chastening hand of an Almighty God, until the consumption decreed hath made a full end of all nations;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 87:7",
+							"text": "That the cry of the saints, and of the blood of the saints, shall cease to come up into the ears of the Lord of Sabaoth, from the earth, to be avenged of their enemies.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 87:8",
+							"text": "Wherefore, stand ye in holy places, and be not moved, until the day of the Lord come; for behold, it cometh quickly, saith the Lord. Amen.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 88,
+					"reference": "D&C 88",
+					"verses": [{
+							"reference": "D&C 88:1",
+							"text": "Verily, thus saith the Lord unto you who have assembled yourselves together to receive his will concerning you:",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 88:2",
+							"text": "Behold, this is pleasing unto your Lord, and the angels rejoice over you; the alms of your prayers have come up into the ears of the Lord of Sabaoth, and are recorded in the book of the names of the sanctified, even them of the celestial world.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 88:3",
+							"text": "Wherefore, I now send upon you another Comforter, even upon you my friends, that it may abide in your hearts, even the Holy Spirit of promise; which other Comforter is the same that I promised unto my disciples, as is recorded in the testimony of John.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 88:4",
+							"text": "This Comforter is the promise which I give unto you of eternal life, even the glory of the celestial kingdom;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 88:5",
+							"text": "Which glory is that of the church of the Firstborn, even of God, the holiest of all, through Jesus Christ his Son\u2014",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 88:6",
+							"text": "He that ascended up on high, as also he descended below all things, in that he comprehended all things, that he might be in all and through all things, the light of truth;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 88:7",
+							"text": "Which truth shineth. This is the light of Christ. As also he is in the sun, and the light of the sun, and the power thereof by which it was made.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 88:8",
+							"text": "As also he is in the moon, and is the light of the moon, and the power thereof by which it was made;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 88:9",
+							"text": "As also the light of the stars, and the power thereof by which they were made;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 88:10",
+							"text": "And the earth also, and the power thereof, even the earth upon which you stand.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 88:11",
+							"text": "And the light which shineth, which giveth you light, is through him who enlighteneth your eyes, which is the same light that quickeneth your understandings;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 88:12",
+							"text": "Which light proceedeth forth from the presence of God to fill the immensity of space\u2014",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 88:13",
+							"text": "The light which is in all things, which giveth life to all things, which is the law by which all things are governed, even the power of God who sitteth upon his throne, who is in the bosom of eternity, who is in the midst of all things.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 88:14",
+							"text": "Now, verily I say unto you, that through the redemption which is made for you is brought to pass the resurrection from the dead.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 88:15",
+							"text": "And the spirit and the body are the soul of man.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 88:16",
+							"text": "And the resurrection from the dead is the redemption of the soul.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 88:17",
+							"text": "And the redemption of the soul is through him that quickeneth all things, in whose bosom it is decreed that the poor and the meek of the earth shall inherit it.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 88:18",
+							"text": "Therefore, it must needs be sanctified from all unrighteousness, that it may be prepared for the celestial glory;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 88:19",
+							"text": "For after it hath filled the measure of its creation, it shall be crowned with glory, even with the presence of God the Father;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 88:20",
+							"text": "That bodies who are of the celestial kingdom may possess it forever and ever; for, for this intent was it made and created, and for this intent are they sanctified.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 88:21",
+							"text": "And they who are not sanctified through the law which I have given unto you, even the law of Christ, must inherit another kingdom, even that of a terrestrial kingdom, or that of a telestial kingdom.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 88:22",
+							"text": "For he who is not able to abide the law of a celestial kingdom cannot abide a celestial glory.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 88:23",
+							"text": "And he who cannot abide the law of a terrestrial kingdom cannot abide a terrestrial glory.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 88:24",
+							"text": "And he who cannot abide the law of a telestial kingdom cannot abide a telestial glory; therefore he is not meet for a kingdom of glory. Therefore he must abide a kingdom which is not a kingdom of glory.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 88:25",
+							"text": "And again, verily I say unto you, the earth abideth the law of a celestial kingdom, for it filleth the measure of its creation, and transgresseth not the law\u2014",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 88:26",
+							"text": "Wherefore, it shall be sanctified; yea, notwithstanding it shall die, it shall be quickened again, and shall abide the power by which it is quickened, and the righteous shall inherit it.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 88:27",
+							"text": "For notwithstanding they die, they also shall rise again, a spiritual body.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 88:28",
+							"text": "They who are of a celestial spirit shall receive the same body which was a natural body; even ye shall receive your bodies, and your glory shall be that glory by which your bodies are quickened.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 88:29",
+							"text": "Ye who are quickened by a portion of the celestial glory shall then receive of the same, even a fulness.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 88:30",
+							"text": "And they who are quickened by a portion of the terrestrial glory shall then receive of the same, even a fulness.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 88:31",
+							"text": "And also they who are quickened by a portion of the telestial glory shall then receive of the same, even a fulness.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 88:32",
+							"text": "And they who remain shall also be quickened; nevertheless, they shall return again to their own place, to enjoy that which they are willing to receive, because they were not willing to enjoy that which they might have received.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 88:33",
+							"text": "For what doth it profit a man if a gift is bestowed upon him, and he receive not the gift? Behold, he rejoices not in that which is given unto him, neither rejoices in him who is the giver of the gift.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 88:34",
+							"text": "And again, verily I say unto you, that which is governed by law is also preserved by law and perfected and sanctified by the same.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 88:35",
+							"text": "That which breaketh a law, and abideth not by law, but seeketh to become a law unto itself, and willeth to abide in sin, and altogether abideth in sin, cannot be sanctified by law, neither by mercy, justice, nor judgment. Therefore, they must remain filthy still.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 88:36",
+							"text": "All kingdoms have a law given;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 88:37",
+							"text": "And there are many kingdoms; for there is no space in the which there is no kingdom; and there is no kingdom in which there is no space, either a greater or a lesser kingdom.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 88:38",
+							"text": "And unto every kingdom is given a law; and unto every law there are certain bounds also and conditions.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 88:39",
+							"text": "All beings who abide not in those conditions are not justified.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 88:40",
+							"text": "For intelligence cleaveth unto intelligence; wisdom receiveth wisdom; truth embraceth truth; virtue loveth virtue; light cleaveth unto light; mercy hath compassion on mercy and claimeth her own; justice continueth its course and claimeth its own; judgment goeth before the face of him who sitteth upon the throne and governeth and executeth all things.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 88:41",
+							"text": "He comprehendeth all things, and all things are before him, and all things are round about him; and he is above all things, and in all things, and is through all things, and is round about all things; and all things are by him, and of him, even God, forever and ever.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 88:42",
+							"text": "And again, verily I say unto you, he hath given a law unto all things, by which they move in their times and their seasons;",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 88:43",
+							"text": "And their courses are fixed, even the courses of the heavens and the earth, which comprehend the earth and all the planets.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 88:44",
+							"text": "And they give light to each other in their times and in their seasons, in their minutes, in their hours, in their days, in their weeks, in their months, in their years\u2014all these are one year with God, but not with man.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 88:45",
+							"text": "The earth rolls upon her wings, and the sun giveth his light by day, and the moon giveth her light by night, and the stars also give their light, as they roll upon their wings in their glory, in the midst of the power of God.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 88:46",
+							"text": "Unto what shall I liken these kingdoms, that ye may understand?",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 88:47",
+							"text": "Behold, all these are kingdoms, and any man who hath seen any or the least of these hath seen God moving in his majesty and power.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 88:48",
+							"text": "I say unto you, he hath seen him; nevertheless, he who came unto his own was not comprehended.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 88:49",
+							"text": "The light shineth in darkness, and the darkness comprehendeth it not; nevertheless, the day shall come when you shall comprehend even God, being quickened in him and by him.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 88:50",
+							"text": "Then shall ye know that ye have seen me, that I am, and that I am the true light that is in you, and that you are in me; otherwise ye could not abound.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 88:51",
+							"text": "Behold, I will liken these kingdoms unto a man having a field, and he sent forth his servants into the field to dig in the field.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 88:52",
+							"text": "And he said unto the first: Go ye and labor in the field, and in the first hour I will come unto you, and ye shall behold the joy of my countenance.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 88:53",
+							"text": "And he said unto the second: Go ye also into the field, and in the second hour I will visit you with the joy of my countenance.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 88:54",
+							"text": "And also unto the third, saying: I will visit you;",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 88:55",
+							"text": "And unto the fourth, and so on unto the twelfth.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 88:56",
+							"text": "And the lord of the field went unto the first in the first hour, and tarried with him all that hour, and he was made glad with the light of the countenance of his lord.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 88:57",
+							"text": "And then he withdrew from the first that he might visit the second also, and the third, and the fourth, and so on unto the twelfth.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 88:58",
+							"text": "And thus they all received the light of the countenance of their lord, every man in his hour, and in his time, and in his season\u2014",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 88:59",
+							"text": "Beginning at the first, and so on unto the last, and from the last unto the first, and from the first unto the last;",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 88:60",
+							"text": "Every man in his own order, until his hour was finished, even according as his lord had commanded him, that his lord might be glorified in him, and he in his lord, that they all might be glorified.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 88:61",
+							"text": "Therefore, unto this parable I will liken all these kingdoms, and the inhabitants thereof\u2014every kingdom in its hour, and in its time, and in its season, even according to the decree which God hath made.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 88:62",
+							"text": "And again, verily I say unto you, my friends, I leave these sayings with you to ponder in your hearts, with this commandment which I give unto you, that ye shall call upon me while I am near\u2014",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 88:63",
+							"text": "Draw near unto me and I will draw near unto you; seek me diligently and ye shall find me; ask, and ye shall receive; knock, and it shall be opened unto you.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 88:64",
+							"text": "Whatsoever ye ask the Father in my name it shall be given unto you, that is expedient for you;",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 88:65",
+							"text": "And if ye ask anything that is not expedient for you, it shall turn unto your condemnation.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 88:66",
+							"text": "Behold, that which you hear is as the voice of one crying in the wilderness\u2014in the wilderness, because you cannot see him\u2014my voice, because my voice is Spirit; my Spirit is truth; truth abideth and hath no end; and if it be in you it shall abound.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 88:67",
+							"text": "And if your eye be single to my glory, your whole bodies shall be filled with light, and there shall be no darkness in you; and that body which is filled with light comprehendeth all things.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 88:68",
+							"text": "Therefore, sanctify yourselves that your minds become single to God, and the days will come that you shall see him; for he will unveil his face unto you, and it shall be in his own time, and in his own way, and according to his own will.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 88:69",
+							"text": "Remember the great and last promise which I have made unto you; cast away your idle thoughts and your excess of laughter far from you.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 88:70",
+							"text": "Tarry ye, tarry ye in this place, and call a solemn assembly, even of those who are the first laborers in this last kingdom.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 88:71",
+							"text": "And let those whom they have warned in their traveling call on the Lord, and ponder the warning in their hearts which they have received, for a little season.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 88:72",
+							"text": "Behold, and lo, I will take care of your flocks, and will raise up elders and send unto them.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 88:73",
+							"text": "Behold, I will hasten my work in its time.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 88:74",
+							"text": "And I give unto you, who are the first laborers in this last kingdom, a commandment that you assemble yourselves together, and organize yourselves, and prepare yourselves, and sanctify yourselves; yea, purify your hearts, and cleanse your hands and your feet before me, that I may make you clean;",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 88:75",
+							"text": "That I may testify unto your Father, and your God, and my God, that you are clean from the blood of this wicked generation; that I may fulfil this promise, this great and last promise, which I have made unto you, when I will.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 88:76",
+							"text": "Also, I give unto you a commandment that ye shall continue in prayer and fasting from this time forth.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 88:77",
+							"text": "And I give unto you a commandment that you shall teach one another the doctrine of the kingdom.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 88:78",
+							"text": "Teach ye diligently and my grace shall attend you, that you may be instructed more perfectly in theory, in principle, in doctrine, in the law of the gospel, in all things that pertain unto the kingdom of God, that are expedient for you to understand;",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 88:79",
+							"text": "Of things both in heaven and in the earth, and under the earth; things which have been, things which are, things which must shortly come to pass; things which are at home, things which are abroad; the wars and the perplexities of the nations, and the judgments which are on the land; and a knowledge also of countries and of kingdoms\u2014",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 88:80",
+							"text": "That ye may be prepared in all things when I shall send you again to magnify the calling whereunto I have called you, and the mission with which I have commissioned you.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 88:81",
+							"text": "Behold, I sent you out to testify and warn the people, and it becometh every man who hath been warned to warn his neighbor.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 88:82",
+							"text": "Therefore, they are left without excuse, and their sins are upon their own heads.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 88:83",
+							"text": "He that seeketh me early shall find me, and shall not be forsaken.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 88:84",
+							"text": "Therefore, tarry ye, and labor diligently, that you may be perfected in your ministry to go forth among the Gentiles for the last time, as many as the mouth of the Lord shall name, to bind up the law and seal up the testimony, and to prepare the saints for the hour of judgment which is to come;",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 88:85",
+							"text": "That their souls may escape the wrath of God, the desolation of abomination which awaits the wicked, both in this world and in the world to come. Verily, I say unto you, let those who are not the first elders continue in the vineyard until the mouth of the Lord shall call them, for their time is not yet come; their garments are not clean from the blood of this generation.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 88:86",
+							"text": "Abide ye in the liberty wherewith ye are made free; entangle not yourselves in sin, but let your hands be clean, until the Lord comes.",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 88:87",
+							"text": "For not many days hence and the earth shall tremble and reel to and fro as a drunken man; and the sun shall hide his face, and shall refuse to give light; and the moon shall be bathed in blood; and the stars shall become exceedingly angry, and shall cast themselves down as a fig that falleth from off a fig tree.",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 88:88",
+							"text": "And after your testimony cometh wrath and indignation upon the people.",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 88:89",
+							"text": "For after your testimony cometh the testimony of earthquakes, that shall cause groanings in the midst of her, and men shall fall upon the ground and shall not be able to stand.",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 88:90",
+							"text": "And also cometh the testimony of the voice of thunderings, and the voice of lightnings, and the voice of tempests, and the voice of the waves of the sea heaving themselves beyond their bounds.",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 88:91",
+							"text": "And all things shall be in commotion; and surely, men's hearts shall fail them; for fear shall come upon all people.",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 88:92",
+							"text": "And angels shall fly through the midst of heaven, crying with a loud voice, sounding the trump of God, saying: Prepare ye, prepare ye, O inhabitants of the earth; for the judgment of our God is come. Behold, and lo, the Bridegroom cometh; go ye out to meet him.",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 88:93",
+							"text": "And immediately there shall appear a great sign in heaven, and all people shall see it together.",
+							"verse": 93
+						},
+						{
+							"reference": "D&C 88:94",
+							"text": "And another angel shall sound his trump, saying: That great church, the mother of abominations, that made all nations drink of the wine of the wrath of her fornication, that persecuteth the saints of God, that shed their blood\u2014she who sitteth upon many waters, and upon the islands of the sea\u2014behold, she is the tares of the earth; she is bound in bundles; her bands are made strong, no man can loose them; therefore, she is ready to be burned. And he shall sound his trump both long and loud, and all nations shall hear it.",
+							"verse": 94
+						},
+						{
+							"reference": "D&C 88:95",
+							"text": "And there shall be silence in heaven for the space of half an hour; and immediately after shall the curtain of heaven be unfolded, as a scroll is unfolded after it is rolled up, and the face of the Lord shall be unveiled;",
+							"verse": 95
+						},
+						{
+							"reference": "D&C 88:96",
+							"text": "And the saints that are upon the earth, who are alive, shall be quickened and be caught up to meet him.",
+							"verse": 96
+						},
+						{
+							"reference": "D&C 88:97",
+							"text": "And they who have slept in their graves shall come forth, for their graves shall be opened; and they also shall be caught up to meet him in the midst of the pillar of heaven\u2014",
+							"verse": 97
+						},
+						{
+							"reference": "D&C 88:98",
+							"text": "They are Christ's, the first fruits, they who shall descend with him first, and they who are on the earth and in their graves, who are first caught up to meet him; and all this by the voice of the sounding of the trump of the angel of God.",
+							"verse": 98
+						},
+						{
+							"reference": "D&C 88:99",
+							"text": "And after this another angel shall sound, which is the second trump; and then cometh the redemption of those who are Christ's at his coming; who have received their part in that prison which is prepared for them, that they might receive the gospel, and be judged according to men in the flesh.",
+							"verse": 99
+						},
+						{
+							"reference": "D&C 88:100",
+							"text": "And again, another trump shall sound, which is the third trump; and then come the spirits of men who are to be judged, and are found under condemnation;",
+							"verse": 100
+						},
+						{
+							"reference": "D&C 88:101",
+							"text": "And these are the rest of the dead; and they live not again until the thousand years are ended, neither again, until the end of the earth.",
+							"verse": 101
+						},
+						{
+							"reference": "D&C 88:102",
+							"text": "And another trump shall sound, which is the fourth trump, saying: There are found among those who are to remain until that great and last day, even the end, who shall remain filthy still.",
+							"verse": 102
+						},
+						{
+							"reference": "D&C 88:103",
+							"text": "And another trump shall sound, which is the fifth trump, which is the fifth angel who committeth the everlasting gospel\u2014flying through the midst of heaven, unto all nations, kindreds, tongues, and people;",
+							"verse": 103
+						},
+						{
+							"reference": "D&C 88:104",
+							"text": "And this shall be the sound of his trump, saying to all people, both in heaven and in earth, and that are under the earth\u2014for every ear shall hear it, and every knee shall bow, and every tongue shall confess, while they hear the sound of the trump, saying: Fear God, and give glory to him who sitteth upon the throne, forever and ever; for the hour of his judgment is come.",
+							"verse": 104
+						},
+						{
+							"reference": "D&C 88:105",
+							"text": "And again, another angel shall sound his trump, which is the sixth angel, saying: She is fallen who made all nations drink of the wine of the wrath of her fornication; she is fallen, is fallen!",
+							"verse": 105
+						},
+						{
+							"reference": "D&C 88:106",
+							"text": "And again, another angel shall sound his trump, which is the seventh angel, saying: It is finished; it is finished! The Lamb of God hath overcome and trodden the wine-press alone, even the wine-press of the fierceness of the wrath of Almighty God.",
+							"verse": 106
+						},
+						{
+							"reference": "D&C 88:107",
+							"text": "And then shall the angels be crowned with the glory of his might, and the saints shall be filled with his glory, and receive their inheritance and be made equal with him.",
+							"verse": 107
+						},
+						{
+							"reference": "D&C 88:108",
+							"text": "And then shall the first angel again sound his trump in the ears of all living, and reveal the secret acts of men, and the mighty works of God in the first thousand years.",
+							"verse": 108
+						},
+						{
+							"reference": "D&C 88:109",
+							"text": "And then shall the second angel sound his trump, and reveal the secret acts of men, and the thoughts and intents of their hearts, and the mighty works of God in the second thousand years\u2014",
+							"verse": 109
+						},
+						{
+							"reference": "D&C 88:110",
+							"text": "And so on, until the seventh angel shall sound his trump; and he shall stand forth upon the land and upon the sea, and swear in the name of him who sitteth upon the throne, that there shall be time no longer; and Satan shall be bound, that old serpent, who is called the devil, and shall not be loosed for the space of a thousand years.",
+							"verse": 110
+						},
+						{
+							"reference": "D&C 88:111",
+							"text": "And then he shall be loosed for a little season, that he may gather together his armies.",
+							"verse": 111
+						},
+						{
+							"reference": "D&C 88:112",
+							"text": "And Michael, the seventh angel, even the archangel, shall gather together his armies, even the hosts of heaven.",
+							"verse": 112
+						},
+						{
+							"reference": "D&C 88:113",
+							"text": "And the devil shall gather together his armies; even the hosts of hell, and shall come up to battle against Michael and his armies.",
+							"verse": 113
+						},
+						{
+							"reference": "D&C 88:114",
+							"text": "And then cometh the battle of the great God; and the devil and his armies shall be cast away into their own place, that they shall not have power over the saints any more at all.",
+							"verse": 114
+						},
+						{
+							"reference": "D&C 88:115",
+							"text": "For Michael shall fight their battles, and shall overcome him who seeketh the throne of him who sitteth upon the throne, even the Lamb.",
+							"verse": 115
+						},
+						{
+							"reference": "D&C 88:116",
+							"text": "This is the glory of God, and the sanctified; and they shall not any more see death.",
+							"verse": 116
+						},
+						{
+							"reference": "D&C 88:117",
+							"text": "Therefore, verily I say unto you, my friends, call your solemn assembly, as I have commanded you.",
+							"verse": 117
+						},
+						{
+							"reference": "D&C 88:118",
+							"text": "And as all have not faith, seek ye diligently and teach one another words of wisdom; yea, seek ye out of the best books words of wisdom; seek learning, even by study and also by faith.",
+							"verse": 118
+						},
+						{
+							"reference": "D&C 88:119",
+							"text": "Organize yourselves; prepare every needful thing; and establish a house, even a house of prayer, a house of fasting, a house of faith, a house of learning, a house of glory, a house of order, a house of God;",
+							"verse": 119
+						},
+						{
+							"reference": "D&C 88:120",
+							"text": "That your incomings may be in the name of the Lord; that your outgoings may be in the name of the Lord; that all your salutations may be in the name of the Lord, with uplifted hands unto the Most High.",
+							"verse": 120
+						},
+						{
+							"reference": "D&C 88:121",
+							"text": "Therefore, cease from all your light speeches, from all laughter, from all your lustful desires, from all your pride and light-mindedness, and from all your wicked doings.",
+							"verse": 121
+						},
+						{
+							"reference": "D&C 88:122",
+							"text": "Appoint among yourselves a teacher, and let not all be spokesmen at once; but let one speak at a time and let all listen unto his sayings, that when all have spoken that all may be edified of all, and that every man may have an equal privilege.",
+							"verse": 122
+						},
+						{
+							"reference": "D&C 88:123",
+							"text": "See that ye love one another; cease to be covetous; learn to impart one to another as the gospel requires.",
+							"verse": 123
+						},
+						{
+							"reference": "D&C 88:124",
+							"text": "Cease to be idle; cease to be unclean; cease to find fault one with another; cease to sleep longer than is needful; retire to thy bed early, that ye may not be weary; arise early, that your bodies and your minds may be invigorated.",
+							"verse": 124
+						},
+						{
+							"reference": "D&C 88:125",
+							"text": "And above all things, clothe yourselves with the bond of charity, as with a mantle, which is the bond of perfectness and peace.",
+							"verse": 125
+						},
+						{
+							"reference": "D&C 88:126",
+							"text": "Pray always, that ye may not faint, until I come. Behold, and lo, I will come quickly, and receive you unto myself. Amen.",
+							"verse": 126
+						},
+						{
+							"reference": "D&C 88:127",
+							"text": "And again, the order of the house prepared for the presidency of the school of the prophets, established for their instruction in all things that are expedient for them, even for all the officers of the church, or in other words, those who are called to the ministry in the church, beginning at the high priests, even down to the deacons\u2014",
+							"verse": 127
+						},
+						{
+							"reference": "D&C 88:128",
+							"text": "And this shall be the order of the house of the presidency of the school: He that is appointed to be president, or teacher, shall be found standing in his place, in the house which shall be prepared for him.",
+							"verse": 128
+						},
+						{
+							"reference": "D&C 88:129",
+							"text": "Therefore, he shall be first in the house of God, in a place that the congregation in the house may hear his words carefully and distinctly, not with loud speech.",
+							"verse": 129
+						},
+						{
+							"reference": "D&C 88:130",
+							"text": "And when he cometh into the house of God, for he should be first in the house\u2014behold, this is beautiful, that he may be an example\u2014",
+							"verse": 130
+						},
+						{
+							"reference": "D&C 88:131",
+							"text": "Let him offer himself in prayer upon his knees before God, in token or remembrance of the everlasting covenant.",
+							"verse": 131
+						},
+						{
+							"reference": "D&C 88:132",
+							"text": "And when any shall come in after him, let the teacher arise, and, with uplifted hands to heaven, yea, even directly, salute his brother or brethren with these words:",
+							"verse": 132
+						},
+						{
+							"reference": "D&C 88:133",
+							"text": "Art thou a brother or brethren? I salute you in the name of the Lord Jesus Christ, in token or remembrance of the everlasting covenant, in which covenant I receive you to fellowship, in a determination that is fixed, immovable, and unchangeable, to be your friend and brother through the grace of God in the bonds of love, to walk in all the commandments of God blameless, in thanksgiving, forever and ever. Amen.",
+							"verse": 133
+						},
+						{
+							"reference": "D&C 88:134",
+							"text": "And he that is found unworthy of this salutation shall not have place among you; for ye shall not suffer that mine house shall be polluted by him.",
+							"verse": 134
+						},
+						{
+							"reference": "D&C 88:135",
+							"text": "And he that cometh in and is faithful before me, and is a brother, or if they be brethren, they shall salute the president or teacher with uplifted hands to heaven, with this same prayer and covenant, or by saying Amen, in token of the same.",
+							"verse": 135
+						},
+						{
+							"reference": "D&C 88:136",
+							"text": "Behold, verily, I say unto you, this is an ensample unto you for a salutation to one another in the house of God, in the school of the prophets.",
+							"verse": 136
+						},
+						{
+							"reference": "D&C 88:137",
+							"text": "And ye are called to do this by prayer and thanksgiving, as the Spirit shall give utterance in all your doings in the house of the Lord, in the school of the prophets, that it may become a sanctuary, a tabernacle of the Holy Spirit to your edification.",
+							"verse": 137
+						},
+						{
+							"reference": "D&C 88:138",
+							"text": "And ye shall not receive any among you into this school save he is clean from the blood of this generation;",
+							"verse": 138
+						},
+						{
+							"reference": "D&C 88:139",
+							"text": "And he shall be received by the ordinance of the washing of feet, for unto this end was the ordinance of the washing of feet instituted.",
+							"verse": 139
+						},
+						{
+							"reference": "D&C 88:140",
+							"text": "And again, the ordinance of washing feet is to be administered by the president, or presiding elder of the church.",
+							"verse": 140
+						},
+						{
+							"reference": "D&C 88:141",
+							"text": "It is to be commenced with prayer; and after partaking of bread and wine, he is to gird himself according to the pattern given in the thirteenth chapter of John's testimony concerning me. Amen.",
+							"verse": 141
+						}
+					]
+				},
+				{
+					"chapter": 89,
+					"reference": "D&C 89",
+					"verses": [{
+							"reference": "D&C 89:1",
+							"text": "A WORD OF WISDOM, for the benefit of the council of high priests, assembled in Kirtland, and the church, and also the saints in Zion\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 89:2",
+							"text": "To be sent greeting; not by commandment or constraint, but by revelation and the word of wisdom, showing forth the order and will of God in the temporal salvation of all saints in the last days\u2014",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 89:3",
+							"text": "Given for a principle with promise, adapted to the capacity of the weak and the weakest of all saints, who are or can be called saints.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 89:4",
+							"text": "Behold, verily, thus saith the Lord unto you: In consequence of evils and designs which do and will exist in the hearts of conspiring men in the last days, I have warned you, and forewarn you, by giving unto you this word of wisdom by revelation\u2014",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 89:5",
+							"text": "That inasmuch as any man drinketh wine or strong drink among you, behold it is not good, neither meet in the sight of your Father, only in assembling yourselves together to offer up your sacraments before him.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 89:6",
+							"text": "And, behold, this should be wine, yea, pure wine of the grape of the vine, of your own make.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 89:7",
+							"text": "And, again, strong drinks are not for the belly, but for the washing of your bodies.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 89:8",
+							"text": "And again, tobacco is not for the body, neither for the belly, and is not good for man, but is an herb for bruises and all sick cattle, to be used with judgment and skill.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 89:9",
+							"text": "And again, hot drinks are not for the body or belly.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 89:10",
+							"text": "And again, verily I say unto you, all wholesome herbs God hath ordained for the constitution, nature, and use of man\u2014",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 89:11",
+							"text": "Every herb in the season thereof, and every fruit in the season thereof; all these to be used with prudence and thanksgiving.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 89:12",
+							"text": "Yea, flesh also of beasts and of the fowls of the air, I, the Lord, have ordained for the use of man with thanksgiving; nevertheless they are to be used sparingly;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 89:13",
+							"text": "And it is pleasing unto me that they should not be used, only in times of winter, or of cold, or famine.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 89:14",
+							"text": "All grain is ordained for the use of man and of beasts, to be the staff of life, not only for man but for the beasts of the field, and the fowls of heaven, and all wild animals that run or creep on the earth;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 89:15",
+							"text": "And these hath God made for the use of man only in times of famine and excess of hunger.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 89:16",
+							"text": "All grain is good for the food of man; as also the fruit of the vine; that which yieldeth fruit, whether in the ground or above the ground\u2014",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 89:17",
+							"text": "Nevertheless, wheat for man, and corn for the ox, and oats for the horse, and rye for the fowls and for swine, and for all beasts of the field, and barley for all useful animals, and for mild drinks, as also other grain.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 89:18",
+							"text": "And all saints who remember to keep and do these sayings, walking in obedience to the commandments, shall receive health in their navel and marrow to their bones;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 89:19",
+							"text": "And shall find wisdom and great treasures of knowledge, even hidden treasures;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 89:20",
+							"text": "And shall run and not be weary, and shall walk and not faint.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 89:21",
+							"text": "And I, the Lord, give unto them a promise, that the destroying angel shall pass by them, as the children of Israel, and not slay them. Amen.",
+							"verse": 21
+						}
+					]
+				},
+				{
+					"chapter": 90,
+					"reference": "D&C 90",
+					"verses": [{
+							"reference": "D&C 90:1",
+							"text": "Thus saith the Lord, verily, verily I say unto you my son, thy sins are forgiven thee, according to thy petition, for thy prayers and the prayers of thy brethren have come up into my ears.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 90:2",
+							"text": "Therefore, thou art blessed from henceforth that bear the keys of the kingdom given unto you; which kingdom is coming forth for the last time.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 90:3",
+							"text": "Verily I say unto you, the keys of this kingdom shall never be taken from you, while thou art in the world, neither in the world to come;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 90:4",
+							"text": "Nevertheless, through you shall the oracles be given to another, yea, even unto the church.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 90:5",
+							"text": "And all they who receive the oracles of God, let them beware how they hold them lest they are accounted as a light thing, and are brought under condemnation thereby, and stumble and fall when the storms descend, and the winds blow, and the rains descend, and beat upon their house.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 90:6",
+							"text": "And again, verily I say unto thy brethren, Sidney Rigdon and Frederick G. Williams, their sins are forgiven them also, and they are accounted as equal with thee in holding the keys of this last kingdom;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 90:7",
+							"text": "As also through your administration the keys of the school of the prophets, which I have commanded to be organized;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 90:8",
+							"text": "That thereby they may be perfected in their ministry for the salvation of Zion, and of the nations of Israel, and of the Gentiles, as many as will believe;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 90:9",
+							"text": "That through your administration they may receive the word, and through their administration the word may go forth unto the ends of the earth, unto the Gentiles first, and then, behold, and lo, they shall turn unto the Jews.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 90:10",
+							"text": "And then cometh the day when the arm of the Lord shall be revealed in power in convincing the nations, the heathen nations, the house of Joseph, of the gospel of their salvation.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 90:11",
+							"text": "For it shall come to pass in that day, that every man shall hear the fulness of the gospel in his own tongue, and in his own language, through those who are ordained unto this power, by the administration of the Comforter, shed forth upon them for the revelation of Jesus Christ.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 90:12",
+							"text": "And now, verily I say unto you, I give unto you a commandment that you continue in the ministry and presidency.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 90:13",
+							"text": "And when you have finished the translation of the prophets, you shall from thenceforth preside over the affairs of the church and the school;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 90:14",
+							"text": "And from time to time, as shall be manifested by the Comforter, receive revelations to unfold the mysteries of the kingdom;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 90:15",
+							"text": "And set in order the churches, and study and learn, and become acquainted with all good books, and with languages, tongues, and people.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 90:16",
+							"text": "And this shall be your business and mission in all your lives, to preside in council, and set in order all the affairs of this church and kingdom.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 90:17",
+							"text": "Be not ashamed, neither confounded; but be admonished in all your high-mindedness and pride, for it bringeth a snare upon your souls.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 90:18",
+							"text": "Set in order your houses; keep slothfulness and uncleanness far from you.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 90:19",
+							"text": "Now, verily I say unto you, let there be a place provided, as soon as it is possible, for the family of thy counselor and scribe, even Frederick G. Williams.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 90:20",
+							"text": "And let mine aged servant, Joseph Smith, Sen., continue with his family upon the place where he now lives; and let it not be sold until the mouth of the Lord shall name.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 90:21",
+							"text": "And let my counselor, even Sidney Rigdon, remain where he now resides until the mouth of the Lord shall name.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 90:22",
+							"text": "And let the bishop search diligently to obtain an agent, and let him be a man who has got riches in store\u2014a man of God, and of strong faith\u2014",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 90:23",
+							"text": "That thereby he may be enabled to discharge every debt; that the storehouse of the Lord may not be brought into disrepute before the eyes of the people.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 90:24",
+							"text": "Search diligently, pray always, and be believing, and all things shall work together for your good, if ye walk uprightly and remember the covenant wherewith ye have covenanted one with another.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 90:25",
+							"text": "Let your families be small, especially mine aged servant Joseph Smith's, Sen., as pertaining to those who do not belong to your families;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 90:26",
+							"text": "That those things that are provided for you, to bring to pass my work, be not taken from you and given to those that are not worthy\u2014",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 90:27",
+							"text": "And thereby you be hindered in accomplishing those things which I have commanded you.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 90:28",
+							"text": "And again, verily I say unto you, it is my will that my handmaid Vienna Jaques should receive money to bear her expenses, and go up unto the land of Zion;",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 90:29",
+							"text": "And the residue of the money may be consecrated unto me, and she be rewarded in mine own due time.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 90:30",
+							"text": "Verily I say unto you, that it is meet in mine eyes that she should go up unto the land of Zion, and receive an inheritance from the hand of the bishop;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 90:31",
+							"text": "That she may settle down in peace inasmuch as she is faithful, and not be idle in her days from thenceforth.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 90:32",
+							"text": "And behold, verily I say unto you, that ye shall write this commandment, and say unto your brethren in Zion, in love greeting, that I have called you also to preside over Zion in mine own due time.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 90:33",
+							"text": "Therefore, let them cease wearying me concerning this matter.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 90:34",
+							"text": "Behold, I say unto you that your brethren in Zion begin to repent, and the angels rejoice over them.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 90:35",
+							"text": "Nevertheless, I am not well pleased with many things; and I am not well pleased with my servant William E. McLellin, neither with my servant Sidney Gilbert; and the bishop also, and others have many things to repent of.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 90:36",
+							"text": "But verily I say unto you, that I, the Lord, will contend with Zion, and plead with her strong ones, and chasten her until she overcomes and is clean before me.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 90:37",
+							"text": "For she shall not be removed out of her place. I, the Lord, have spoken it. Amen.",
+							"verse": 37
+						}
+					]
+				},
+				{
+					"chapter": 91,
+					"reference": "D&C 91",
+					"verses": [{
+							"reference": "D&C 91:1",
+							"text": "Verily, thus saith the Lord unto you concerning the Apocrypha\u2014There are many things contained therein that are true, and it is mostly translated correctly;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 91:2",
+							"text": "There are many things contained therein that are not true, which are interpolations by the hands of men.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 91:3",
+							"text": "Verily, I say unto you, that it is not needful that the Apocrypha should be translated.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 91:4",
+							"text": "Therefore, whoso readeth it, let him understand, for the Spirit manifesteth truth;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 91:5",
+							"text": "And whoso is enlightened by the Spirit shall obtain benefit therefrom;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 91:6",
+							"text": "And whoso receiveth not by the Spirit, cannot be benefited. Therefore it is not needful that it should be translated. Amen.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 92,
+					"reference": "D&C 92",
+					"verses": [{
+							"reference": "D&C 92:1",
+							"text": "Verily, thus saith the Lord, I give unto the united order, organized agreeable to the commandment previously given, a revelation and commandment concerning my servant Frederick G. Williams, that ye shall receive him into the order. What I say unto one I say unto all.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 92:2",
+							"text": "And again, I say unto you my servant Frederick G. Williams, you shall be a lively member in this order; and inasmuch as you are faithful in keeping all former commandments you shall be blessed forever. Amen.",
+							"verse": 2
+						}
+					]
+				},
+				{
+					"chapter": 93,
+					"reference": "D&C 93",
+					"verses": [{
+							"reference": "D&C 93:1",
+							"text": "Verily, thus saith the Lord: It shall come to pass that every soul who forsaketh his sins and cometh unto me, and calleth on my name, and obeyeth my voice, and keepeth my commandments, shall see my face and know that I am;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 93:2",
+							"text": "And that I am the true light that lighteth every man that cometh into the world;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 93:3",
+							"text": "And that I am in the Father, and the Father in me, and the Father and I are one\u2014",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 93:4",
+							"text": "The Father because he gave me of his fulness, and the Son because I was in the world and made flesh my tabernacle, and dwelt among the sons of men.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 93:5",
+							"text": "I was in the world and received of my Father, and the works of him were plainly manifest.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 93:6",
+							"text": "And John saw and bore record of the fulness of my glory, and the fulness of John's record is hereafter to be revealed.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 93:7",
+							"text": "And he bore record, saying: I saw his glory, that he was in the beginning, before the world was;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 93:8",
+							"text": "Therefore, in the beginning the Word was, for he was the Word, even the messenger of salvation\u2014",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 93:9",
+							"text": "The light and the Redeemer of the world; the Spirit of truth, who came into the world, because the world was made by him, and in him was the life of men and the light of men.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 93:10",
+							"text": "The worlds were made by him; men were made by him; all things were made by him, and through him, and of him.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 93:11",
+							"text": "And I, John, bear record that I beheld his glory, as the glory of the Only Begotten of the Father, full of grace and truth, even the Spirit of truth, which came and dwelt in the flesh, and dwelt among us.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 93:12",
+							"text": "And I, John, saw that he received not of the fulness at the first, but received grace for grace;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 93:13",
+							"text": "And he received not of the fulness at first, but continued from grace to grace, until he received a fulness;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 93:14",
+							"text": "And thus he was called the Son of God, because he received not of the fulness at the first.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 93:15",
+							"text": "And I, John, bear record, and lo, the heavens were opened, and the Holy Ghost descended upon him in the form of a dove, and sat upon him, and there came a voice out of heaven saying: This is my beloved Son.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 93:16",
+							"text": "And I, John, bear record that he received a fulness of the glory of the Father;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 93:17",
+							"text": "And he received all power, both in heaven and on earth, and the glory of the Father was with him, for he dwelt in him.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 93:18",
+							"text": "And it shall come to pass, that if you are faithful you shall receive the fulness of the record of John.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 93:19",
+							"text": "I give unto you these sayings that you may understand and know how to worship, and know what you worship, that you may come unto the Father in my name, and in due time receive of his fulness.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 93:20",
+							"text": "For if you keep my commandments you shall receive of his fulness, and be glorified in me as I am in the Father; therefore, I say unto you, you shall receive grace for grace.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 93:21",
+							"text": "And now, verily I say unto you, I was in the beginning with the Father, and am the Firstborn;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 93:22",
+							"text": "And all those who are begotten through me are partakers of the glory of the same, and are the church of the Firstborn.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 93:23",
+							"text": "Ye were also in the beginning with the Father; that which is Spirit, even the Spirit of truth;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 93:24",
+							"text": "And truth is knowledge of things as they are, and as they were, and as they are to come;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 93:25",
+							"text": "And whatsoever is more or less than this is the spirit of that wicked one who was a liar from the beginning.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 93:26",
+							"text": "The Spirit of truth is of God. I am the Spirit of truth, and John bore record of me, saying: He received a fulness of truth, yea, even of all truth;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 93:27",
+							"text": "And no man receiveth a fulness unless he keepeth his commandments.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 93:28",
+							"text": "He that keepeth his commandments receiveth truth and light, until he is glorified in truth and knoweth all things.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 93:29",
+							"text": "Man was also in the beginning with God. Intelligence, or the light of truth, was not created or made, neither indeed can be.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 93:30",
+							"text": "All truth is independent in that sphere in which God has placed it, to act for itself, as all intelligence also; otherwise there is no existence.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 93:31",
+							"text": "Behold, here is the agency of man, and here is the condemnation of man; because that which was from the beginning is plainly manifest unto them, and they receive not the light.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 93:32",
+							"text": "And every man whose spirit receiveth not the light is under condemnation.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 93:33",
+							"text": "For man is spirit. The elements are eternal, and spirit and element, inseparably connected, receive a fulness of joy;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 93:34",
+							"text": "And when separated, man cannot receive a fulness of joy.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 93:35",
+							"text": "The elements are the tabernacle of God; yea, man is the tabernacle of God, even temples; and whatsoever temple is defiled, God shall destroy that temple.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 93:36",
+							"text": "The glory of God is intelligence, or, in other words, light and truth.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 93:37",
+							"text": "Light and truth forsake that evil one.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 93:38",
+							"text": "Every spirit of man was innocent in the beginning; and God having redeemed man from the fall, men became again, in their infant state, innocent before God.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 93:39",
+							"text": "And that wicked one cometh and taketh away light and truth, through disobedience, from the children of men, and because of the tradition of their fathers.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 93:40",
+							"text": "But I have commanded you to bring up your children in light and truth.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 93:41",
+							"text": "But verily I say unto you, my servant Frederick G. Williams, you have continued under this condemnation;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 93:42",
+							"text": "You have not taught your children light and truth, according to the commandments; and that wicked one hath power, as yet, over you, and this is the cause of your affliction.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 93:43",
+							"text": "And now a commandment I give unto you\u2014if you will be delivered you shall set in order your own house, for there are many things that are not right in your house.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 93:44",
+							"text": "Verily, I say unto my servant Sidney Rigdon, that in some things he hath not kept the commandments concerning his children; therefore, first set in order thy house.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 93:45",
+							"text": "Verily, I say unto my servant Joseph Smith, Jun., or in other words, I will call you friends, for you are my friends, and ye shall have an inheritance with me\u2014",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 93:46",
+							"text": "I called you servants for the world's sake, and ye are their servants for my sake\u2014",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 93:47",
+							"text": "And now, verily I say unto Joseph Smith, Jun.\u2014You have not kept the commandments, and must needs stand rebuked before the Lord;",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 93:48",
+							"text": "Your family must needs repent and forsake some things, and give more earnest heed unto your sayings, or be removed out of their place.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 93:49",
+							"text": "What I say unto one I say unto all; pray always lest that wicked one have power in you, and remove you out of your place.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 93:50",
+							"text": "My servant Newel K. Whitney also, a bishop of my church, hath need to be chastened, and set in order his family, and see that they are more diligent and concerned at home, and pray always, or they shall be removed out of their place.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 93:51",
+							"text": "Now, I say unto you, my friends, let my servant Sidney Rigdon go on his journey, and make haste, and also proclaim the acceptable year of the Lord, and the gospel of salvation, as I shall give him utterance; and by your prayer of faith with one consent I will uphold him.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 93:52",
+							"text": "And let my servants Joseph Smith, Jun., and Frederick G. Williams make haste also, and it shall be given them even according to the prayer of faith; and inasmuch as you keep my sayings you shall not be confounded in this world, nor in the world to come.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 93:53",
+							"text": "And, verily I say unto you, that it is my will that you should hasten to translate my scriptures, and to obtain a knowledge of history, and of countries, and of kingdoms, of laws of God and man, and all this for the salvation of Zion. Amen.",
+							"verse": 53
+						}
+					]
+				},
+				{
+					"chapter": 94,
+					"reference": "D&C 94",
+					"verses": [{
+							"reference": "D&C 94:1",
+							"text": "And again, verily I say unto you, my friends, a commandment I give unto you, that ye shall commence a work of laying out and preparing a beginning and foundation of the city of the stake of Zion, here in the land of Kirtland, beginning at my house.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 94:2",
+							"text": "And behold, it must be done according to the pattern which I have given unto you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 94:3",
+							"text": "And let the first lot on the south be consecrated unto me for the building of a house for the presidency, for the work of the presidency, in obtaining revelations; and for the work of the ministry of the presidency, in all things pertaining to the church and kingdom.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 94:4",
+							"text": "Verily I say unto you, that it shall be built fifty-five by sixty-five feet in the width thereof and in the length thereof, in the inner court.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 94:5",
+							"text": "And there shall be a lower court and a higher court, according to the pattern which shall be given unto you hereafter.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 94:6",
+							"text": "And it shall be dedicated unto the Lord from the foundation thereof, according to the order of the priesthood, according to the pattern which shall be given unto you hereafter.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 94:7",
+							"text": "And it shall be wholly dedicated unto the Lord for the work of the presidency.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 94:8",
+							"text": "And ye shall not suffer any unclean thing to come in unto it; and my glory shall be there, and my presence shall be there.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 94:9",
+							"text": "But if there shall come into it any unclean thing, my glory shall not be there; and my presence shall not come into it.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 94:10",
+							"text": "And again, verily I say unto you, the second lot on the south shall be dedicated unto me for the building of a house unto me, for the work of the printing of the translation of my scriptures, and all things whatsoever I shall command you.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 94:11",
+							"text": "And it shall be fifty-five by sixty-five feet in the width thereof and the length thereof, in the inner court; and there shall be a lower and a higher court.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 94:12",
+							"text": "And this house shall be wholly dedicated unto the Lord from the foundation thereof, for the work of the printing, in all things whatsoever I shall command you, to be holy, undefiled, according to the pattern in all things as it shall be given unto you.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 94:13",
+							"text": "And on the third lot shall my servant Hyrum Smith receive his inheritance.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 94:14",
+							"text": "And on the first and second lots on the north shall my servants Reynolds Cahoon and Jared Carter receive their inheritances\u2014",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 94:15",
+							"text": "That they may do the work which I have appointed unto them, to be a committee to build mine houses, according to the commandment, which I, the Lord God, have given unto you.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 94:16",
+							"text": "These two houses are not to be built until I give unto you a commandment concerning them.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 94:17",
+							"text": "And now I give unto you no more at this time. Amen.",
+							"verse": 17
+						}
+					]
+				},
+				{
+					"chapter": 95,
+					"reference": "D&C 95",
+					"verses": [{
+							"reference": "D&C 95:1",
+							"text": "Verily, thus saith the Lord unto you whom I love, and whom I love I also chasten that their sins may be forgiven, for with the chastisement I prepare a way for their deliverance in all things out of temptation, and I have loved you\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 95:2",
+							"text": "Wherefore, ye must needs be chastened and stand rebuked before my face;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 95:3",
+							"text": "For ye have sinned against me a very grievous sin, in that ye have not considered the great commandment in all things, that I have given unto you concerning the building of mine house;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 95:4",
+							"text": "For the preparation wherewith I design to prepare mine apostles to prune my vineyard for the last time, that I may bring to pass my strange act, that I may pour out my Spirit upon all flesh\u2014",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 95:5",
+							"text": "But behold, verily I say unto you, that there are many who have been ordained among you, whom I have called but few of them are chosen.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 95:6",
+							"text": "They who are not chosen have sinned a very grievous sin, in that they are walking in darkness at noon-day.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 95:7",
+							"text": "And for this cause I gave unto you a commandment that you should call your solemn assembly, that your fastings and your mourning might come up into the ears of the Lord of Sabaoth, which is by interpretation, the creator of the first day, the beginning and the end.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 95:8",
+							"text": "Yea, verily I say unto you, I gave unto you a commandment that you should build a house, in the which house I design to endow those whom I have chosen with power from on high;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 95:9",
+							"text": "For this is the promise of the Father unto you; therefore I command you to tarry, even as mine apostles at Jerusalem.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 95:10",
+							"text": "Nevertheless, my servants sinned a very grievous sin; and contentions arose in the school of the prophets; which was very grievous unto me, saith your Lord; therefore I sent them forth to be chastened.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 95:11",
+							"text": "Verily I say unto you, it is my will that you should build a house. If you keep my commandments you shall have power to build it.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 95:12",
+							"text": "If you keep not my commandments, the love of the Father shall not continue with you, therefore you shall walk in darkness.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 95:13",
+							"text": "Now here is wisdom, and the mind of the Lord\u2014let the house be built, not after the manner of the world, for I give not unto you that ye shall live after the manner of the world;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 95:14",
+							"text": "Therefore, let it be built after the manner which I shall show unto three of you, whom ye shall appoint and ordain unto this power.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 95:15",
+							"text": "And the size thereof shall be fifty and five feet in width, and let it be sixty-five feet in length, in the inner court thereof.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 95:16",
+							"text": "And let the lower part of the inner court be dedicated unto me for your sacrament offering, and for your preaching, and your fasting, and your praying, and the offering up of your most holy desires unto me, saith your Lord.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 95:17",
+							"text": "And let the higher part of the inner court be dedicated unto me for the school of mine apostles, saith Son Ahman; or, in other words, Alphus; or, in other words, Omegus; even Jesus Christ your Lord. Amen.",
+							"verse": 17
+						}
+					]
+				},
+				{
+					"chapter": 96,
+					"reference": "D&C 96",
+					"verses": [{
+							"reference": "D&C 96:1",
+							"text": "Behold, I say unto you, here is wisdom, whereby ye may know how to act concerning this matter, for it is expedient in me that this stake that I have set for the strength of Zion should be made strong.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 96:2",
+							"text": "Therefore, let my servant Newel K. Whitney take charge of the place which is named among you, upon which I design to build mine holy house.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 96:3",
+							"text": "And again, let it be divided into lots, according to wisdom, for the benefit of those who seek inheritances, as it shall be determined in council among you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 96:4",
+							"text": "Therefore, take heed that ye see to this matter, and that portion that is necessary to benefit mine order, for the purpose of bringing forth my word to the children of men.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 96:5",
+							"text": "For behold, verily I say unto you, this is the most expedient in me, that my word should go forth unto the children of men, for the purpose of subduing the hearts of the children of men for your good. Even so. Amen.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 96:6",
+							"text": "And again, verily I say unto you, it is wisdom and expedient in me, that my servant John Johnson whose offering I have accepted, and whose prayers I have heard, unto whom I give a promise of eternal life inasmuch as he keepeth my commandments from henceforth\u2014",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 96:7",
+							"text": "For he is a descendant of Joseph and a partaker of the blessings of the promise made unto his fathers\u2014",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 96:8",
+							"text": "Verily I say unto you, it is expedient in me that he should become a member of the order, that he may assist in bringing forth my word unto the children of men.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 96:9",
+							"text": "Therefore ye shall ordain him unto this blessing, and he shall seek diligently to take away incumbrances that are upon the house named among you, that he may dwell therein. Even so. Amen.",
+							"verse": 9
+						}
+					]
+				},
+				{
+					"chapter": 97,
+					"reference": "D&C 97",
+					"verses": [{
+							"reference": "D&C 97:1",
+							"text": "Verily I say unto you my friends, I speak unto you with my voice, even the voice of my Spirit, that I may show unto you my will concerning your brethren in the land of Zion, many of whom are truly humble and are seeking diligently to learn wisdom and to find truth.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 97:2",
+							"text": "Verily, verily I say unto you, blessed are such, for they shall obtain; for I, the Lord, show mercy unto all the meek, and upon all whomsoever I will, that I may be justified when I shall bring them unto judgment.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 97:3",
+							"text": "Behold, I say unto you, concerning the school in Zion, I, the Lord, am well pleased that there should be a school in Zion, and also with my servant Parley P. Pratt, for he abideth in me.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 97:4",
+							"text": "And inasmuch as he continueth to abide in me he shall continue to preside over the school in the land of Zion until I shall give unto him other commandments.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 97:5",
+							"text": "And I will bless him with a multiplicity of blessings, in expounding all scriptures and mysteries to the edification of the school, and of the church in Zion.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 97:6",
+							"text": "And to the residue of the school, I, the Lord, am willing to show mercy; nevertheless, there are those that must needs be chastened, and their works shall be made known.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 97:7",
+							"text": "The ax is laid at the root of the trees; and every tree that bringeth not forth good fruit shall be hewn down and cast into the fire. I, the Lord, have spoken it.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 97:8",
+							"text": "Verily I say unto you, all among them who know their hearts are honest, and are broken, and their spirits contrite, and are willing to observe their covenants by sacrifice\u2014yea, every sacrifice which I, the Lord, shall command\u2014they are accepted of me.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 97:9",
+							"text": "For I, the Lord, will cause them to bring forth as a very fruitful tree which is planted in a goodly land, by a pure stream, that yieldeth much precious fruit.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 97:10",
+							"text": "Verily I say unto you, that it is my will that a house should be built unto me in the land of Zion, like unto the pattern which I have given you.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 97:11",
+							"text": "Yea, let it be built speedily, by the tithing of my people.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 97:12",
+							"text": "Behold, this is the tithing and the sacrifice which I, the Lord, require at their hands, that there may be a house built unto me for the salvation of Zion\u2014",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 97:13",
+							"text": "For a place of thanksgiving for all saints, and for a place of instruction for all those who are called to the work of the ministry in all their several callings and offices;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 97:14",
+							"text": "That they may be perfected in the understanding of their ministry, in theory, in principle, and in doctrine, in all things pertaining to the kingdom of God on the earth, the keys of which kingdom have been conferred upon you.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 97:15",
+							"text": "And inasmuch as my people build a house unto me in the name of the Lord, and do not suffer any unclean thing to come into it, that it be not defiled, my glory shall rest upon it;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 97:16",
+							"text": "Yea, and my presence shall be there, for I will come into it, and all the pure in heart that shall come into it shall see God.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 97:17",
+							"text": "But if it be defiled I will not come into it, and my glory shall not be there; for I will not come into unholy temples.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 97:18",
+							"text": "And, now, behold, if Zion do these things she shall prosper, and spread herself and become very glorious, very great, and very terrible.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 97:19",
+							"text": "And the nations of the earth shall honor her, and shall say: Surely Zion is the city of our God, and surely Zion cannot fall, neither be moved out of her place, for God is there, and the hand of the Lord is there;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 97:20",
+							"text": "And he hath sworn by the power of his might to be her salvation and her high tower.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 97:21",
+							"text": "Therefore, verily, thus saith the Lord, let Zion rejoice, for this is Zion\u2014THE PURE IN HEART; therefore, let Zion rejoice, while all the wicked shall mourn.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 97:22",
+							"text": "For behold, and lo, vengeance cometh speedily upon the ungodly as the whirlwind; and who shall escape it?",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 97:23",
+							"text": "The Lord's scourge shall pass over by night and by day, and the report thereof shall vex all people; yea, it shall not be stayed until the Lord come;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 97:24",
+							"text": "For the indignation of the Lord is kindled against their abominations and all their wicked works.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 97:25",
+							"text": "Nevertheless, Zion shall escape if she observe to do all things whatsoever I have commanded her.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 97:26",
+							"text": "But if she observe not to do whatsoever I have commanded her, I will visit her according to all her works, with sore affliction, with pestilence, with plague, with sword, with vengeance, with devouring fire.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 97:27",
+							"text": "Nevertheless, let it be read this once to her ears, that I, the Lord, have accepted of her offering; and if she sin no more none of these things shall come upon her;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 97:28",
+							"text": "And I will bless her with blessings, and multiply a multiplicity of blessings upon her, and upon her generations forever and ever, saith the Lord your God. Amen.",
+							"verse": 28
+						}
+					]
+				},
+				{
+					"chapter": 98,
+					"reference": "D&C 98",
+					"verses": [{
+							"reference": "D&C 98:1",
+							"text": "Verily I say unto you my friends, fear not, let your hearts be comforted; yea, rejoice evermore, and in everything give thanks;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 98:2",
+							"text": "Waiting patiently on the Lord, for your prayers have entered into the ears of the Lord of Sabaoth, and are recorded with this seal and testament\u2014the Lord hath sworn and decreed that they shall be granted.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 98:3",
+							"text": "Therefore, he giveth this promise unto you, with an immutable covenant that they shall be fulfilled; and all things wherewith you have been afflicted shall work together for your good, and to my name's glory, saith the Lord.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 98:4",
+							"text": "And now, verily I say unto you concerning the laws of the land, it is my will that my people should observe to do all things whatsoever I command them.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 98:5",
+							"text": "And that law of the land which is constitutional, supporting that principle of freedom in maintaining rights and privileges, belongs to all mankind, and is justifiable before me.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 98:6",
+							"text": "Therefore, I, the Lord, justify you, and your brethren of my church, in befriending that law which is the constitutional law of the land;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 98:7",
+							"text": "And as pertaining to law of man, whatsoever is more or less than this, cometh of evil.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 98:8",
+							"text": "I, the Lord God, make you free, therefore ye are free indeed; and the law also maketh you free.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 98:9",
+							"text": "Nevertheless, when the wicked rule the people mourn.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 98:10",
+							"text": "Wherefore, honest men and wise men should be sought for diligently, and good men and wise men ye should observe to uphold; otherwise whatsoever is less than these cometh of evil.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 98:11",
+							"text": "And I give unto you a commandment, that ye shall forsake all evil and cleave unto all good, that ye shall live by every word which proceedeth forth out of the mouth of God.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 98:12",
+							"text": "For he will give unto the faithful line upon line, precept upon precept; and I will try you and prove you herewith.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 98:13",
+							"text": "And whoso layeth down his life in my cause, for my name's sake, shall find it again, even life eternal.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 98:14",
+							"text": "Therefore, be not afraid of your enemies, for I have decreed in my heart, saith the Lord, that I will prove you in all things, whether you will abide in my covenant, even unto death, that you may be found worthy.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 98:15",
+							"text": "For if ye will not abide in my covenant ye are not worthy of me.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 98:16",
+							"text": "Therefore, renounce war and proclaim peace, and seek diligently to turn the hearts of the children to their fathers, and the hearts of the fathers to the children;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 98:17",
+							"text": "And again, the hearts of the Jews unto the prophets, and the prophets unto the Jews; lest I come and smite the whole earth with a curse, and all flesh be consumed before me.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 98:18",
+							"text": "Let not your hearts be troubled; for in my Father's house are many mansions, and I have prepared a place for you; and where my Father and I am, there ye shall be also.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 98:19",
+							"text": "Behold, I, the Lord, am not well pleased with many who are in the church at Kirtland;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 98:20",
+							"text": "For they do not forsake their sins, and their wicked ways, the pride of their hearts, and their covetousness, and all their detestable things, and observe the words of wisdom and eternal life which I have given unto them.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 98:21",
+							"text": "Verily I say unto you, that I, the Lord, will chasten them and will do whatsoever I list, if they do not repent and observe all things whatsoever I have said unto them.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 98:22",
+							"text": "And again I say unto you, if ye observe to do whatsoever I command you, I, the Lord, will turn away all wrath and indignation from you, and the gates of hell shall not prevail against you.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 98:23",
+							"text": "Now, I speak unto you concerning your families\u2014if men will smite you, or your families, once, and ye bear it patiently and revile not against them, neither seek revenge, ye shall be rewarded;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 98:24",
+							"text": "But if ye bear it not patiently, it shall be accounted unto you as being meted out as a just measure unto you.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 98:25",
+							"text": "And again, if your enemy shall smite you the second time, and you revile not against your enemy, and bear it patiently, your reward shall be an hundred-fold.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 98:26",
+							"text": "And again, if he shall smite you the third time, and ye bear it patiently, your reward shall be doubled unto you four-fold;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 98:27",
+							"text": "And these three testimonies shall stand against your enemy if he repent not, and shall not be blotted out.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 98:28",
+							"text": "And now, verily I say unto you, if that enemy shall escape my vengeance, that he be not brought into judgment before me, then ye shall see to it that ye warn him in my name, that he come no more upon you, neither upon your family, even your children's children unto the third and fourth generation.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 98:29",
+							"text": "And then, if he shall come upon you or your children, or your children's children unto the third and fourth generation, I have delivered thine enemy into thine hands;",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 98:30",
+							"text": "And then if thou wilt spare him, thou shalt be rewarded for thy righteousness; and also thy children and thy children's children unto the third and fourth generation.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 98:31",
+							"text": "Nevertheless, thine enemy is in thine hands; and if thou rewardest him according to his works thou art justified; if he has sought thy life, and thy life is endangered by him, thine enemy is in thine hands and thou art justified.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 98:32",
+							"text": "Behold, this is the law I gave unto my servant Nephi, and thy fathers, Joseph, and Jacob, and Isaac, and Abraham, and all mine ancient prophets and apostles.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 98:33",
+							"text": "And again, this is the law that I gave unto mine ancients, that they should not go out unto battle against any nation, kindred, tongue, or people, save I, the Lord, commanded them.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 98:34",
+							"text": "And if any nation, tongue, or people should proclaim war against them, they should first lift a standard of peace unto that people, nation, or tongue;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 98:35",
+							"text": "And if that people did not accept the offering of peace, neither the second nor the third time, they should bring these testimonies before the Lord;",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 98:36",
+							"text": "Then I, the Lord, would give unto them a commandment, and justify them in going out to battle against that nation, tongue, or people.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 98:37",
+							"text": "And I, the Lord, would fight their battles, and their children's battles, and their children's children's, until they had avenged themselves on all their enemies, to the third and fourth generation.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 98:38",
+							"text": "Behold, this is an ensample unto all people, saith the Lord your God, for justification before me.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 98:39",
+							"text": "And again, verily I say unto you, if after thine enemy has come upon thee the first time, he repent and come unto thee praying thy forgiveness, thou shalt forgive him, and shalt hold it no more as a testimony against thine enemy\u2014",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 98:40",
+							"text": "And so on unto the second and third time; and as oft as thine enemy repenteth of the trespass wherewith he has trespassed against thee, thou shalt forgive him, until seventy times seven.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 98:41",
+							"text": "And if he trespass against thee and repent not the first time, nevertheless thou shalt forgive him.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 98:42",
+							"text": "And if he trespass against thee the second time, and repent not, nevertheless thou shalt forgive him.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 98:43",
+							"text": "And if he trespass against thee the third time, and repent not, thou shalt also forgive him.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 98:44",
+							"text": "But if he trespass against thee the fourth time thou shalt not forgive him, but shalt bring these testimonies before the Lord; and they shall not be blotted out until he repent and reward thee four-fold in all things wherewith he has trespassed against thee.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 98:45",
+							"text": "And if he do this, thou shalt forgive him with all thine heart; and if he do not this, I, the Lord, will avenge thee of thine enemy an hundred-fold;",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 98:46",
+							"text": "And upon his children, and upon his children's children of all them that hate me, unto the third and fourth generation.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 98:47",
+							"text": "But if the children shall repent, or the children's children, and turn to the Lord their God, with all their hearts and with all their might, mind, and strength, and restore four-fold for all their trespasses wherewith they have trespassed, or wherewith their fathers have trespassed, or their fathers' fathers, then thine indignation shall be turned away;",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 98:48",
+							"text": "And vengeance shall no more come upon them, saith the Lord thy God, and their trespasses shall never be brought any more as a testimony before the Lord against them. Amen.",
+							"verse": 48
+						}
+					]
+				},
+				{
+					"chapter": 99,
+					"reference": "D&C 99",
+					"verses": [{
+							"reference": "D&C 99:1",
+							"text": "Behold, thus saith the Lord unto my servant John Murdock\u2014thou art called to go into the eastern countries from house to house, from village to village, and from city to city, to proclaim mine everlasting gospel unto the inhabitants thereof, in the midst of persecution and wickedness.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 99:2",
+							"text": "And who receiveth you receiveth me; and you shall have power to declare my word in the demonstration of my Holy Spirit.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 99:3",
+							"text": "And who receiveth you as a little child, receiveth my kingdom; and blessed are they, for they shall obtain mercy.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 99:4",
+							"text": "And whoso rejecteth you shall be rejected of my Father and his house; and you shall cleanse your feet in the secret places by the way for a testimony against them.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 99:5",
+							"text": "And behold, and lo, I come quickly to judgment, to convince all of their ungodly deeds which they have committed against me, as it is written of me in the volume of the book.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 99:6",
+							"text": "And now, verily I say unto you, that it is not expedient that you should go until your children are provided for, and sent up kindly unto the bishop of Zion.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 99:7",
+							"text": "And after a few years, if thou desirest of me, thou mayest go up also unto the goodly land, to possess thine inheritance;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 99:8",
+							"text": "Otherwise thou shalt continue proclaiming my gospel until thou be taken. Amen.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 100,
+					"reference": "D&C 100",
+					"verses": [{
+							"reference": "D&C 100:1",
+							"text": "Verily, thus saith the Lord unto you, my friends Sidney and Joseph, your families are well; they are in mine hands, and I will do with them as seemeth me good; for in me there is all power.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 100:2",
+							"text": "Therefore, follow me, and listen to the counsel which I shall give unto you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 100:3",
+							"text": "Behold, and lo, I have much people in this place, in the regions round about; and an effectual door shall be opened in the regions round about in this eastern land.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 100:4",
+							"text": "Therefore, I, the Lord, have suffered you to come unto this place; for thus it was expedient in me for the salvation of souls.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 100:5",
+							"text": "Therefore, verily I say unto you, lift up your voices unto this people; speak the thoughts that I shall put into your hearts, and you shall not be confounded before men;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 100:6",
+							"text": "For it shall be given you in the very hour, yea, in the very moment, what ye shall say.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 100:7",
+							"text": "But a commandment I give unto you, that ye shall declare whatsoever thing ye declare in my name, in solemnity of heart, in the spirit of meekness, in all things.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 100:8",
+							"text": "And I give unto you this promise, that inasmuch as ye do this the Holy Ghost shall be shed forth in bearing record unto all things whatsoever ye shall say.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 100:9",
+							"text": "And it is expedient in me that you, my servant Sidney, should be a spokesman unto this people; yea, verily, I will ordain you unto this calling, even to be a spokesman unto my servant Joseph.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 100:10",
+							"text": "And I will give unto him power to be mighty in testimony.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 100:11",
+							"text": "And I will give unto thee power to be mighty in expounding all scriptures, that thou mayest be a spokesman unto him, and he shall be a revelator unto thee, that thou mayest know the certainty of all things pertaining to the things of my kingdom on the earth.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 100:12",
+							"text": "Therefore, continue your journey and let your hearts rejoice; for behold, and lo, I am with you even unto the end.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 100:13",
+							"text": "And now I give unto you a word concerning Zion. Zion shall be redeemed, although she is chastened for a little season.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 100:14",
+							"text": "Thy brethren, my servants Orson Hyde and John Gould, are in my hands; and inasmuch as they keep my commandments they shall be saved.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 100:15",
+							"text": "Therefore, let your hearts be comforted; for all things shall work together for good to them that walk uprightly, and to the sanctification of the church.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 100:16",
+							"text": "For I will raise up unto myself a pure people, that will serve me in righteousness;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 100:17",
+							"text": "And all that call upon the name of the Lord, and keep his commandments, shall be saved. Even so. Amen.",
+							"verse": 17
+						}
+					]
+				}
+			]
+		},
+		{
+			"book": "D&C 101-125",
+			"chapters": [{
+					"chapter": 101,
+					"reference": "D&C 101",
+					"verses": [{
+							"reference": "D&C 101:1",
+							"text": "Verily I say unto you, concerning your brethren who have been afflicted, and persecuted, and cast out from the land of their inheritance\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 101:2",
+							"text": "I, the Lord, have suffered the affliction to come upon them, wherewith they have been afflicted, in consequence of their transgressions;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 101:3",
+							"text": "Yet I will own them, and they shall be mine in that day when I shall come to make up my jewels.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 101:4",
+							"text": "Therefore, they must needs be chastened and tried, even as Abraham, who was commanded to offer up his only son.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 101:5",
+							"text": "For all those who will not endure chastening, but deny me, cannot be sanctified.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 101:6",
+							"text": "Behold, I say unto you, there were jarrings, and contentions, and envyings, and strifes, and lustful and covetous desires among them; therefore by these things they polluted their inheritances.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 101:7",
+							"text": "They were slow to hearken unto the voice of the Lord their God; therefore, the Lord their God is slow to hearken unto their prayers, to answer them in the day of their trouble.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 101:8",
+							"text": "In the day of their peace they esteemed lightly my counsel; but, in the day of their trouble, of necessity they feel after me.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 101:9",
+							"text": "Verily I say unto you, notwithstanding their sins, my bowels are filled with compassion towards them. I will not utterly cast them off; and in the day of wrath I will remember mercy.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 101:10",
+							"text": "I have sworn, and the decree hath gone forth by a former commandment which I have given unto you, that I would let fall the sword of mine indignation in behalf of my people; and even as I have said, it shall come to pass.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 101:11",
+							"text": "Mine indignation is soon to be poured out without measure upon all nations; and this will I do when the cup of their iniquity is full.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 101:12",
+							"text": "And in that day all who are found upon the watch-tower, or in other words, all mine Israel, shall be saved.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 101:13",
+							"text": "And they that have been scattered shall be gathered.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 101:14",
+							"text": "And all they who have mourned shall be comforted.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 101:15",
+							"text": "And all they who have given their lives for my name shall be crowned.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 101:16",
+							"text": "Therefore, let your hearts be comforted concerning Zion; for all flesh is in mine hands; be still and know that I am God.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 101:17",
+							"text": "Zion shall not be moved out of her place, notwithstanding her children are scattered.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 101:18",
+							"text": "They that remain, and are pure in heart, shall return, and come to their inheritances, they and their children, with songs of everlasting joy, to build up the waste places of Zion\u2014",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 101:19",
+							"text": "And all these things that the prophets might be fulfilled.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 101:20",
+							"text": "And, behold, there is none other place appointed than that which I have appointed; neither shall there be any other place appointed than that which I have appointed, for the work of the gathering of my saints\u2014",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 101:21",
+							"text": "Until the day cometh when there is found no more room for them; and then I have other places which I will appoint unto them, and they shall be called stakes, for the curtains or the strength of Zion.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 101:22",
+							"text": "Behold, it is my will, that all they who call on my name, and worship me according to mine everlasting gospel, should gather together, and stand in holy places;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 101:23",
+							"text": "And prepare for the revelation which is to come, when the veil of the covering of my temple, in my tabernacle, which hideth the earth, shall be taken off, and all flesh shall see me together.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 101:24",
+							"text": "And every corruptible thing, both of man, or of the beasts of the field, or of the fowls of the heavens, or of the fish of the sea, that dwells upon all the face of the earth, shall be consumed;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 101:25",
+							"text": "And also that of element shall melt with fervent heat; and all things shall become new, that my knowledge and glory may dwell upon all the earth.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 101:26",
+							"text": "And in that day the enmity of man, and the enmity of beasts, yea, the enmity of all flesh, shall cease from before my face.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 101:27",
+							"text": "And in that day whatsoever any man shall ask, it shall be given unto him.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 101:28",
+							"text": "And in that day Satan shall not have power to tempt any man.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 101:29",
+							"text": "And there shall be no sorrow because there is no death.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 101:30",
+							"text": "In that day an infant shall not die until he is old; and his life shall be as the age of a tree;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 101:31",
+							"text": "And when he dies he shall not sleep, that is to say in the earth, but shall be changed in the twinkling of an eye, and shall be caught up, and his rest shall be glorious.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 101:32",
+							"text": "Yea, verily I say unto you, in that day when the Lord shall come, he shall reveal all things\u2014",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 101:33",
+							"text": "Things which have passed, and hidden things which no man knew, things of the earth, by which it was made, and the purpose and the end thereof\u2014",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 101:34",
+							"text": "Things most precious, things that are above, and things that are beneath, things that are in the earth, and upon the earth, and in heaven.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 101:35",
+							"text": "And all they who suffer persecution for my name, and endure in faith, though they are called to lay down their lives for my sake yet shall they partake of all this glory.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 101:36",
+							"text": "Wherefore, fear not even unto death; for in this world your joy is not full, but in me your joy is full.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 101:37",
+							"text": "Therefore, care not for the body, neither the life of the body; but care for the soul, and for the life of the soul.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 101:38",
+							"text": "And seek the face of the Lord always, that in patience ye may possess your souls, and ye shall have eternal life.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 101:39",
+							"text": "When men are called unto mine everlasting gospel, and covenant with an everlasting covenant, they are accounted as the salt of the earth and the savor of men;",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 101:40",
+							"text": "They are called to be the savor of men; therefore, if that salt of the earth lose its savor, behold, it is thenceforth good for nothing only to be cast out and trodden under the feet of men.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 101:41",
+							"text": "Behold, here is wisdom concerning the children of Zion, even many, but not all; they were found transgressors, therefore they must needs be chastened\u2014",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 101:42",
+							"text": "He that exalteth himself shall be abased, and he that abaseth himself shall be exalted.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 101:43",
+							"text": "And now, I will show unto you a parable, that you may know my will concerning the redemption of Zion.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 101:44",
+							"text": "A certain nobleman had a spot of land, very choice; and he said unto his servants: Go ye unto my vineyard, even upon this very choice piece of land, and plant twelve olive trees;",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 101:45",
+							"text": "And set watchmen round about them, and build a tower, that one may overlook the land round about, to be a watchman upon the tower, that mine olive trees may not be broken down when the enemy shall come to spoil and take upon themselves the fruit of my vineyard.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 101:46",
+							"text": "Now, the servants of the nobleman went and did as their lord commanded them, and planted the olive trees, and built a hedge round about, and set watchmen, and began to build a tower.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 101:47",
+							"text": "And while they were yet laying the foundation thereof, they began to say among themselves: And what need hath my lord of this tower?",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 101:48",
+							"text": "And consulted for a long time, saying among themselves: What need hath my lord of this tower, seeing this is a time of peace?",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 101:49",
+							"text": "Might not this money be given to the exchangers? For there is no need of these things.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 101:50",
+							"text": "And while they were at variance one with another they became very slothful, and they hearkened not unto the commandments of their lord.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 101:51",
+							"text": "And the enemy came by night, and broke down the hedge; and the servants of the nobleman arose and were affrighted, and fled; and the enemy destroyed their works, and broke down the olive trees.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 101:52",
+							"text": "Now, behold, the nobleman, the lord of the vineyard, called upon his servants, and said unto them, Why! what is the cause of this great evil?",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 101:53",
+							"text": "Ought ye not to have done even as I commanded you, and\u2014after ye had planted the vineyard, and built the hedge round about, and set watchmen upon the walls thereof\u2014built the tower also, and set a watchman upon the tower, and watched for my vineyard, and not have fallen asleep, lest the enemy should come upon you?",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 101:54",
+							"text": "And behold, the watchman upon the tower would have seen the enemy while he was yet afar off; and then ye could have made ready and kept the enemy from breaking down the hedge thereof, and saved my vineyard from the hands of the destroyer.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 101:55",
+							"text": "And the lord of the vineyard said unto one of his servants: Go and gather together the residue of my servants, and take all the strength of mine house, which are my warriors, my young men, and they that are of middle age also among all my servants, who are the strength of mine house, save those only whom I have appointed to tarry;",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 101:56",
+							"text": "And go ye straightway unto the land of my vineyard, and redeem my vineyard; for it is mine; I have bought it with money.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 101:57",
+							"text": "Therefore, get ye straightway unto my land; break down the walls of mine enemies; throw down their tower, and scatter their watchmen.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 101:58",
+							"text": "And inasmuch as they gather together against you, avenge me of mine enemies, that by and by I may come with the residue of mine house and possess the land.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 101:59",
+							"text": "And the servant said unto his lord: When shall these things be?",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 101:60",
+							"text": "And he said unto his servant: When I will; go ye straightway, and do all things whatsoever I have commanded you;",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 101:61",
+							"text": "And this shall be my seal and blessing upon you\u2014a faithful and wise steward in the midst of mine house, a ruler in my kingdom.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 101:62",
+							"text": "And his servant went straightway, and did all things whatsoever his lord commanded him; and after many days all things were fulfilled.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 101:63",
+							"text": "Again, verily I say unto you, I will show unto you wisdom in me concerning all the churches, inasmuch as they are willing to be guided in a right and proper way for their salvation\u2014",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 101:64",
+							"text": "That the work of the gathering together of my saints may continue, that I may build them up unto my name upon holy places; for the time of harvest is come, and my word must needs be fulfilled.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 101:65",
+							"text": "Therefore, I must gather together my people, according to the parable of the wheat and the tares, that the wheat may be secured in the garners to possess eternal life, and be crowned with celestial glory, when I shall come in the kingdom of my Father to reward every man according as his work shall be;",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 101:66",
+							"text": "While the tares shall be bound in bundles, and their bands made strong, that they may be burned with unquenchable fire.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 101:67",
+							"text": "Therefore, a commandment I give unto all the churches, that they shall continue to gather together unto the places which I have appointed.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 101:68",
+							"text": "Nevertheless, as I have said unto you in a former commandment, let not your gathering be in haste, nor by flight; but let all things be prepared before you.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 101:69",
+							"text": "And in order that all things be prepared before you, observe the commandment which I have given concerning these things\u2014",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 101:70",
+							"text": "Which saith, or teacheth, to purchase all the lands with money, which can be purchased for money, in the region round about the land which I have appointed to be the land of Zion, for the beginning of the gathering of my saints;",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 101:71",
+							"text": "All the land which can be purchased in Jackson county, and the counties round about, and leave the residue in mine hand.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 101:72",
+							"text": "Now, verily I say unto you, let all the churches gather together all their moneys; let these things be done in their time, but not in haste; and observe to have all things prepared before you.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 101:73",
+							"text": "And let honorable men be appointed, even wise men, and send them to purchase these lands.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 101:74",
+							"text": "And the churches in the eastern countries, when they are built up, if they will hearken unto this counsel they may buy lands and gather together upon them; and in this way they may establish Zion.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 101:75",
+							"text": "There is even now already in store sufficient, yea, even an abundance, to redeem Zion, and establish her waste places, no more to be thrown down, were the churches, who call themselves after my name, willing to hearken to my voice.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 101:76",
+							"text": "And again I say unto you, those who have been scattered by their enemies, it is my will that they should continue to importune for redress, and redemption, by the hands of those who are placed as rulers and are in authority over you\u2014",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 101:77",
+							"text": "According to the laws and constitution of the people, which I have suffered to be established, and should be maintained for the rights and protection of all flesh, according to just and holy principles;",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 101:78",
+							"text": "That every man may act in doctrine and principle pertaining to futurity, according to the moral agency which I have given unto him, that every man may be accountable for his own sins in the day of judgment.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 101:79",
+							"text": "Therefore, it is not right that any man should be in bondage one to another.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 101:80",
+							"text": "And for this purpose have I established the Constitution of this land, by the hands of wise men whom I raised up unto this very purpose, and redeemed the land by the shedding of blood.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 101:81",
+							"text": "Now, unto what shall I liken the children of Zion? I will liken them unto the parable of the woman and the unjust judge, for men ought always to pray and not to faint, which saith\u2014",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 101:82",
+							"text": "There was in a city a judge which feared not God, neither regarded man.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 101:83",
+							"text": "And there was a widow in that city, and she came unto him, saying: Avenge me of mine adversary.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 101:84",
+							"text": "And he would not for a while, but afterward he said within himself: Though I fear not God, nor regard man, yet because this widow troubleth me I will avenge her, lest by her continual coming she weary me.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 101:85",
+							"text": "Thus will I liken the children of Zion.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 101:86",
+							"text": "Let them importune at the feet of the judge;",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 101:87",
+							"text": "And if he heed them not, let them importune at the feet of the governor;",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 101:88",
+							"text": "And if the governor heed them not, let them importune at the feet of the president;",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 101:89",
+							"text": "And if the president heed them not, then will the Lord arise and come forth out of his hiding place, and in his fury vex the nation;",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 101:90",
+							"text": "And in his hot displeasure, and in his fierce anger, in his time, will cut off those wicked, unfaithful, and unjust stewards, and appoint them their portion among hypocrites, and unbelievers;",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 101:91",
+							"text": "Even in outer darkness, where there is weeping, and wailing, and gnashing of teeth.",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 101:92",
+							"text": "Pray ye, therefore, that their ears may be opened unto your cries, that I may be merciful unto them, that these things may not come upon them.",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 101:93",
+							"text": "What I have said unto you must needs be, that all men may be left without excuse;",
+							"verse": 93
+						},
+						{
+							"reference": "D&C 101:94",
+							"text": "That wise men and rulers may hear and know that which they have never considered;",
+							"verse": 94
+						},
+						{
+							"reference": "D&C 101:95",
+							"text": "That I may proceed to bring to pass my act, my strange act, and perform my work, my strange work, that men may discern between the righteous and the wicked, saith your God.",
+							"verse": 95
+						},
+						{
+							"reference": "D&C 101:96",
+							"text": "And again, I say unto you, it is contrary to my commandment and my will that my servant Sidney Gilbert should sell my storehouse, which I have appointed unto my people, into the hands of mine enemies.",
+							"verse": 96
+						},
+						{
+							"reference": "D&C 101:97",
+							"text": "Let not that which I have appointed be polluted by mine enemies, by the consent of those who call themselves after my name;",
+							"verse": 97
+						},
+						{
+							"reference": "D&C 101:98",
+							"text": "For this is a very sore and grievous sin against me, and against my people, in consequence of those things which I have decreed and which are soon to befall the nations.",
+							"verse": 98
+						},
+						{
+							"reference": "D&C 101:99",
+							"text": "Therefore, it is my will that my people should claim, and hold claim upon that which I have appointed unto them, though they should not be permitted to dwell thereon.",
+							"verse": 99
+						},
+						{
+							"reference": "D&C 101:100",
+							"text": "Nevertheless, I do not say they shall not dwell thereon; for inasmuch as they bring forth fruit and works meet for my kingdom they shall dwell thereon.",
+							"verse": 100
+						},
+						{
+							"reference": "D&C 101:101",
+							"text": "They shall build, and another shall not inherit it; they shall plant vineyards, and they shall eat the fruit thereof. Even so. Amen.",
+							"verse": 101
+						}
+					]
+				},
+				{
+					"chapter": 102,
+					"reference": "D&C 102",
+					"signature": "Oliver Cowdery, Orson Hyde, Clerks",
+					"verses": [{
+							"reference": "D&C 102:1",
+							"text": "This day a general council of twenty-four high priests assembled at the house of Joseph Smith, Jun., by revelation, and proceeded to organize the high council of the church of Christ, which was to consist of twelve high priests, and one or three presidents as the case might require.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 102:2",
+							"text": "The high council was appointed by revelation for the purpose of settling important difficulties which might arise in the church, which could not be settled by the church or the bishop's council to the satisfaction of the parties.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 102:3",
+							"text": "Joseph Smith, Jun., Sidney Rigdon and Frederick G. Williams were acknowledged presidents by the voice of the council; and Joseph Smith, Sen., John Smith, Joseph Coe, John Johnson, Martin Harris, John S. Carter, Jared Carter, Oliver Cowdery, Samuel H. Smith, Orson Hyde, Sylvester Smith, and Luke Johnson, high priests, were chosen to be a standing council for the church, by the unanimous voice of the council.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 102:4",
+							"text": "The above-named councilors were then asked whether they accepted their appointments, and whether they would act in that office according to the law of heaven, to which they all answered that they accepted their appointments, and would fill their offices according to the grace of God bestowed upon them.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 102:5",
+							"text": "The number composing the council, who voted in the name and for the church in appointing the above-named councilors were forty-three, as follows: nine high priests, seventeen elders, four priests, and thirteen members.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 102:6",
+							"text": "Voted: that the high council cannot have power to act without seven of the above-named councilors, or their regularly appointed successors are present.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 102:7",
+							"text": "These seven shall have power to appoint other high priests, whom they may consider worthy and capable to act in the place of absent councilors.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 102:8",
+							"text": "Voted: that whenever any vacancy shall occur by the death, removal from office for transgression, or removal from the bounds of this church government, of any one of the above-named councilors, it shall be filled by the nomination of the president or presidents, and sanctioned by the voice of a general council of high priests, convened for that purpose, to act in the name of the church.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 102:9",
+							"text": "The president of the church, who is also the president of the council, is appointed by revelation, and acknowledged in his administration by the voice of the church.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 102:10",
+							"text": "And it is according to the dignity of his office that he should preside over the council of the church; and it is his privilege to be assisted by two other presidents, appointed after the same manner that he himself was appointed.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 102:11",
+							"text": "And in case of the absence of one or both of those who are appointed to assist him, he has power to preside over the council without an assistant; and in case he himself is absent, the other presidents have power to preside in his stead, both or either of them.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 102:12",
+							"text": "Whenever a high council of the church of Christ is regularly organized, according to the foregoing pattern, it shall be the duty of the twelve councilors to cast lots by numbers, and thereby ascertain who of the twelve shall speak first, commencing with number one and so in succession to number twelve.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 102:13",
+							"text": "Whenever this council convenes to act upon any case, the twelve councilors shall consider whether it is a difficult one or not; if it is not, two only of the councilors shall speak upon it, according to the form above written.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 102:14",
+							"text": "But if it is thought to be difficult, four shall be appointed; and if more difficult, six; but in no case shall more than six be appointed to speak.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 102:15",
+							"text": "The accused, in all cases, has a right to one-half of the council, to prevent insult or injustice.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 102:16",
+							"text": "And the councilors appointed to speak before the council are to present the case, after the evidence is examined, in its true light before the council; and every man is to speak according to equity and justice.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 102:17",
+							"text": "Those councilors who draw even numbers, that is, 2, 4, 6, 8, 10, and 12, are the individuals who are to stand up in behalf of the accused, and prevent insult and injustice.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 102:18",
+							"text": "In all cases the accuser and the accused shall have a privilege of speaking for themselves before the council, after the evidences are heard and the councilors who are appointed to speak on the case have finished their remarks.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 102:19",
+							"text": "After the evidences are heard, the councilors, accuser and accused have spoken, the president shall give a decision according to the understanding which he shall have of the case, and call upon the twelve councilors to sanction the same by their vote.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 102:20",
+							"text": "But should the remaining councilors, who have not spoken, or any one of them, after hearing the evidences and pleadings impartially, discover an error in the decision of the president, they can manifest it, and the case shall have a re-hearing.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 102:21",
+							"text": "And if, after a careful re-hearing, any additional light is shown upon the case, the decision shall be altered accordingly.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 102:22",
+							"text": "But in case no additional light is given, the first decision shall stand, the majority of the council having power to determine the same.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 102:23",
+							"text": "In case of difficulty respecting doctrine or principle, if there is not a sufficiency written to make the case clear to the minds of the council, the president may inquire and obtain the mind of the Lord by revelation.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 102:24",
+							"text": "The high priests, when abroad, have power to call and organize a council after the manner of the foregoing, to settle difficulties, when the parties or either of them shall request it.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 102:25",
+							"text": "And the said council of high priests shall have power to appoint one of their own number to preside over such council for the time being.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 102:26",
+							"text": "It shall be the duty of said council to transmit, immediately, a copy of their proceedings, with a full statement of the testimony accompanying their decision, to the high council of the seat of the First Presidency of the Church.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 102:27",
+							"text": "Should the parties or either of them be dissatisfied with the decision of said council, they may appeal to the high council of the seat of the First Presidency of the Church, and have a re-hearing, which case shall there be conducted, according to the former pattern written, as though no such decision had been made.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 102:28",
+							"text": "This council of high priests abroad is only to be called on the most difficult cases of church matters; and no common or ordinary case is to be sufficient to call such council.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 102:29",
+							"text": "The traveling or located high priests abroad have power to say whether it is necessary to call such a council or not.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 102:30",
+							"text": "There is a distinction between the high council or traveling high priests abroad, and the traveling high council composed of the twelve apostles, in their decisions.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 102:31",
+							"text": "From the decision of the former there can be an appeal; but from the decision of the latter there cannot.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 102:32",
+							"text": "The latter can only be called in question by the general authorities of the church in case of transgression.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 102:33",
+							"text": "Resolved: that the president or presidents of the seat of the First Presidency of the Church shall have power to determine whether any such case, as may be appealed, is justly entitled to a re-hearing, after examining the appeal and the evidences and statements accompanying it.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 102:34",
+							"text": "The twelve councilors then proceeded to cast lots or ballot, to ascertain who should speak first, and the following was the result, namely: 1, Oliver Cowdery; 2, Joseph Coe; 3, Samuel H. Smith; 4, Luke Johnson; 5, John S. Carter; 6, Sylvester Smith; 7, John Johnson; 8, Orson Hyde; 9, Jared Carter; 10, Joseph Smith, Sen.; 11, John Smith; 12, Martin Harris. After prayer the conference adjourned.",
+							"verse": 34
+						}
+					]
+				},
+				{
+					"chapter": 103,
+					"reference": "D&C 103",
+					"verses": [{
+							"reference": "D&C 103:1",
+							"text": "Verily I say unto you, my friends, behold, I will give unto you a revelation and commandment, that you may know how to act in the discharge of your duties concerning the salvation and redemption of your brethren, who have been scattered on the land of Zion;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 103:2",
+							"text": "Being driven and smitten by the hands of mine enemies, on whom I will pour out my wrath without measure in mine own time.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 103:3",
+							"text": "For I have suffered them thus far, that they might fill up the measure of their iniquities, that their cup might be full;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 103:4",
+							"text": "And that those who call themselves after my name might be chastened for a little season with a sore and grievous chastisement, because they did not hearken altogether unto the precepts and commandments which I gave unto them.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 103:5",
+							"text": "But verily I say unto you, that I have decreed a decree which my people shall realize, inasmuch as they hearken from this very hour unto the counsel which I, the Lord their God, shall give unto them.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 103:6",
+							"text": "Behold they shall, for I have decreed it, begin to prevail against mine enemies from this very hour.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 103:7",
+							"text": "And by hearkening to observe all the words which I, the Lord their God, shall speak unto them, they shall never cease to prevail until the kingdoms of the world are subdued under my feet, and the earth is given unto the saints, to possess it forever and ever.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 103:8",
+							"text": "But inasmuch as they keep not my commandments, and hearken not to observe all my words, the kingdoms of the world shall prevail against them.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 103:9",
+							"text": "For they were set to be a light unto the world, and to be the saviors of men;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 103:10",
+							"text": "And inasmuch as they are not the saviors of men, they are as salt that has lost its savor, and is thenceforth good for nothing but to be cast out and trodden under foot of men.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 103:11",
+							"text": "But verily I say unto you, I have decreed that your brethren which have been scattered shall return to the lands of their inheritances, and shall build up the waste places of Zion.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 103:12",
+							"text": "For after much tribulation, as I have said unto you in a former commandment, cometh the blessing.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 103:13",
+							"text": "Behold, this is the blessing which I have promised after your tribulations, and the tribulations of your brethren\u2014your redemption, and the redemption of your brethren, even their restoration to the land of Zion, to be established, no more to be thrown down.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 103:14",
+							"text": "Nevertheless, if they pollute their inheritances they shall be thrown down; for I will not spare them if they pollute their inheritances.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 103:15",
+							"text": "Behold, I say unto you, the redemption of Zion must needs come by power;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 103:16",
+							"text": "Therefore, I will raise up unto my people a man, who shall lead them like as Moses led the children of Israel.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 103:17",
+							"text": "For ye are the children of Israel, and of the seed of Abraham, and ye must needs be led out of bondage by power, and with a stretched-out arm.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 103:18",
+							"text": "And as your fathers were led at the first, even so shall the redemption of Zion be.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 103:19",
+							"text": "Therefore, let not your hearts faint, for I say not unto you as I said unto your fathers: Mine angel shall go up before you, but not my presence.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 103:20",
+							"text": "But I say unto you: Mine angels shall go up before you, and also my presence, and in time ye shall possess the goodly land.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 103:21",
+							"text": "Verily, verily I say unto you, that my servant Joseph Smith, Jun., is the man to whom I likened the servant to whom the Lord of the vineyard spake in the parable which I have given unto you.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 103:22",
+							"text": "Therefore let my servant Joseph Smith, Jun., say unto the strength of my house, my young men and the middle aged\u2014Gather yourselves together unto the land of Zion, upon the land which I have bought with money that has been consecrated unto me.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 103:23",
+							"text": "And let all the churches send up wise men with their moneys, and purchase lands even as I have commanded them.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 103:24",
+							"text": "And inasmuch as mine enemies come against you to drive you from my goodly land, which I have consecrated to be the land of Zion, even from your own lands after these testimonies, which ye have brought before me against them, ye shall curse them;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 103:25",
+							"text": "And whomsoever ye curse, I will curse, and ye shall avenge me of mine enemies.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 103:26",
+							"text": "And my presence shall be with you even in avenging me of mine enemies, unto the third and fourth generation of them that hate me.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 103:27",
+							"text": "Let no man be afraid to lay down his life for my sake; for whoso layeth down his life for my sake shall find it again.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 103:28",
+							"text": "And whoso is not willing to lay down his life for my sake is not my disciple.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 103:29",
+							"text": "It is my will that my servant Sidney Rigdon shall lift up his voice in the congregations in the eastern countries, in preparing the churches to keep the commandments which I have given unto them concerning the restoration and redemption of Zion.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 103:30",
+							"text": "It is my will that my servant Parley P. Pratt and my servant Lyman Wight should not return to the land of their brethren, until they have obtained companies to go up unto the land of Zion, by tens, or by twenties, or by fifties, or by an hundred, until they have obtained to the number of five hundred of the strength of my house.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 103:31",
+							"text": "Behold this is my will; ask and ye shall receive; but men do not always do my will.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 103:32",
+							"text": "Therefore, if you cannot obtain five hundred, seek diligently that peradventure you may obtain three hundred.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 103:33",
+							"text": "And if ye cannot obtain three hundred, seek diligently that peradventure ye may obtain one hundred.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 103:34",
+							"text": "But verily I say unto you, a commandment I give unto you, that ye shall not go up unto the land of Zion until you have obtained a hundred of the strength of my house, to go up with you unto the land of Zion.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 103:35",
+							"text": "Therefore, as I said unto you, ask and ye shall receive; pray earnestly that peradventure my servant Joseph Smith, Jun., may go with you, and preside in the midst of my people, and organize my kingdom upon the consecrated land, and establish the children of Zion upon the laws and commandments which have been and which shall be given unto you.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 103:36",
+							"text": "All victory and glory is brought to pass unto you through your diligence, faithfulness, and prayers of faith.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 103:37",
+							"text": "Let my servant Parley P. Pratt journey with my servant Joseph Smith, Jun.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 103:38",
+							"text": "Let my servant Lyman Wight journey with my servant Sidney Rigdon.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 103:39",
+							"text": "Let my servant Hyrum Smith journey with my servant Frederick G. Williams.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 103:40",
+							"text": "Let my servant Orson Hyde journey with my servant Orson Pratt, whithersoever my servant Joseph Smith, Jun., shall counsel them, in obtaining the fulfilment of these commandments which I have given unto you, and leave the residue in my hands. Even so. Amen.",
+							"verse": 40
+						}
+					]
+				},
+				{
+					"chapter": 104,
+					"reference": "D&C 104",
+					"verses": [{
+							"reference": "D&C 104:1",
+							"text": "Verily I say unto you, my friends, I give unto you counsel, and a commandment, concerning all the properties which belong to the order which I commanded to be organized and established, to be a united order, and an everlasting order for the benefit of my church, and for the salvation of men until I come\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 104:2",
+							"text": "With promise immutable and unchangeable, that inasmuch as those whom I commanded were faithful they should be blessed with a multiplicity of blessings;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 104:3",
+							"text": "But inasmuch as they were not faithful they were nigh unto cursing.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 104:4",
+							"text": "Therefore, inasmuch as some of my servants have not kept the commandment, but have broken the covenant through covetousness, and with feigned words, I have cursed them with a very sore and grievous curse.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 104:5",
+							"text": "For I, the Lord, have decreed in my heart, that inasmuch as any man belonging to the order shall be found a transgressor, or, in other words, shall break the covenant with which ye are bound, he shall be cursed in his life, and shall be trodden down by whom I will;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 104:6",
+							"text": "For I, the Lord, am not to be mocked in these things\u2014",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 104:7",
+							"text": "And all this that the innocent among you may not be condemned with the unjust; and that the guilty among you may not escape; because I, the Lord, have promised unto you a crown of glory at my right hand.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 104:8",
+							"text": "Therefore, inasmuch as you are found transgressors, you cannot escape my wrath in your lives.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 104:9",
+							"text": "Inasmuch as ye are cut off for transgression, ye cannot escape the buffetings of Satan until the day of redemption.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 104:10",
+							"text": "And I now give unto you power from this very hour, that if any man among you, of the order, is found a transgressor and repenteth not of the evil, that ye shall deliver him over unto the buffetings of Satan; and he shall not have power to bring evil upon you.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 104:11",
+							"text": "It is wisdom in me; therefore, a commandment I give unto you, that ye shall organize yourselves and appoint every man his stewardship;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 104:12",
+							"text": "That every man may give an account unto me of the stewardship which is appointed unto him.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 104:13",
+							"text": "For it is expedient that I, the Lord, should make every man accountable, as a steward over earthly blessings, which I have made and prepared for my creatures.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 104:14",
+							"text": "I, the Lord, stretched out the heavens, and built the earth, my very handiwork; and all things therein are mine.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 104:15",
+							"text": "And it is my purpose to provide for my saints, for all things are mine.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 104:16",
+							"text": "But it must needs be done in mine own way; and behold this is the way that I, the Lord, have decreed to provide for my saints, that the poor shall be exalted, in that the rich are made low.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 104:17",
+							"text": "For the earth is full, and there is enough and to spare; yea, I prepared all things, and have given unto the children of men to be agents unto themselves.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 104:18",
+							"text": "Therefore, if any man shall take of the abundance which I have made, and impart not his portion, according to the law of my gospel, unto the poor and the needy, he shall, with the wicked, lift up his eyes in hell, being in torment.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 104:19",
+							"text": "And now, verily I say unto you, concerning the properties of the order\u2014",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 104:20",
+							"text": "Let my servant Sidney Rigdon have appointed unto him the place where he now resides, and the lot of the tannery for his stewardship, for his support while he is laboring in my vineyard, even as I will, when I shall command him.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 104:21",
+							"text": "And let all things be done according to the counsel of the order, and united consent or voice of the order, which dwell in the land of Kirtland.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 104:22",
+							"text": "And this stewardship and blessing, I, the Lord, confer upon my servant Sidney Rigdon for a blessing upon him, and his seed after him;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 104:23",
+							"text": "And I will multiply blessings upon him, inasmuch as he will be humble before me.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 104:24",
+							"text": "And again, let my servant Martin Harris have appointed unto him, for his stewardship, the lot of land which my servant John Johnson obtained in exchange for his former inheritance, for him and his seed after him;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 104:25",
+							"text": "And inasmuch as he is faithful, I will multiply blessings upon him and his seed after him.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 104:26",
+							"text": "And let my servant Martin Harris devote his moneys for the proclaiming of my words, according as my servant Joseph Smith, Jun., shall direct.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 104:27",
+							"text": "And again, let my servant Frederick G. Williams have the place upon which he now dwells.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 104:28",
+							"text": "And let my servant Oliver Cowdery have the lot which is set off joining the house, which is to be for the printing office, which is lot number one, and also the lot upon which his father resides.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 104:29",
+							"text": "And let my servants Frederick G. Williams and Oliver Cowdery have the printing office and all things that pertain unto it.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 104:30",
+							"text": "And this shall be their stewardship which shall be appointed unto them.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 104:31",
+							"text": "And inasmuch as they are faithful, behold I will bless, and multiply blessings upon them.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 104:32",
+							"text": "And this is the beginning of the stewardship which I have appointed them, for them and their seed after them.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 104:33",
+							"text": "And, inasmuch as they are faithful, I will multiply blessings upon them and their seed after them, even a multiplicity of blessings.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 104:34",
+							"text": "And again, let my servant John Johnson have the house in which he lives, and the inheritance, all save the ground which has been reserved for the building of my houses, which pertains to that inheritance, and those lots which have been named for my servant Oliver Cowdery.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 104:35",
+							"text": "And inasmuch as he is faithful, I will multiply blessings upon him.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 104:36",
+							"text": "And it is my will that he should sell the lots that are laid off for the building up of the city of my saints, inasmuch as it shall be made known to him by the voice of the Spirit, and according to the counsel of the order, and by the voice of the order.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 104:37",
+							"text": "And this is the beginning of the stewardship which I have appointed unto him, for a blessing unto him and his seed after him.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 104:38",
+							"text": "And inasmuch as he is faithful, I will multiply a multiplicity of blessings upon him.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 104:39",
+							"text": "And again, let my servant Newel K. Whitney have appointed unto him the houses and lot where he now resides, and the lot and building on which the mercantile establishment stands, and also the lot which is on the corner south of the mercantile establishment, and also the lot on which the ashery is situated.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 104:40",
+							"text": "And all this I have appointed unto my servant Newel K. Whitney for his stewardship, for a blessing upon him and his seed after him, for the benefit of the mercantile establishment of my order which I have established for my stake in the land of Kirtland.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 104:41",
+							"text": "Yea, verily, this is the stewardship which I have appointed unto my servant N. K. Whitney, even this whole mercantile establishment, him and his agent, and his seed after him.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 104:42",
+							"text": "And inasmuch as he is faithful in keeping my commandments, which I have given unto him, I will multiply blessings upon him and his seed after him, even a multiplicity of blessings.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 104:43",
+							"text": "And again, let my servant Joseph Smith, Jun., have appointed unto him the lot which is laid off for the building of my house, which is forty rods long and twelve wide, and also the inheritance upon which his father now resides;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 104:44",
+							"text": "And this is the beginning of the stewardship which I have appointed unto him, for a blessing upon him, and upon his father.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 104:45",
+							"text": "For behold, I have reserved an inheritance for his father, for his support; therefore he shall be reckoned in the house of my servant Joseph Smith, Jun.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 104:46",
+							"text": "And I will multiply blessings upon the house of my servant Joseph Smith, Jun., inasmuch as he is faithful, even a multiplicity of blessings.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 104:47",
+							"text": "And now, a commandment I give unto you concerning Zion, that you shall no longer be bound as a united order to your brethren of Zion, only on this wise\u2014",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 104:48",
+							"text": "After you are organized, you shall be called the United Order of the Stake of Zion, the City of Kirtland. And your brethren, after they are organized, shall be called the United Order of the City of Zion.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 104:49",
+							"text": "And they shall be organized in their own names, and in their own name; and they shall do their business in their own name, and in their own names;",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 104:50",
+							"text": "And you shall do your business in your own name, and in your own names.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 104:51",
+							"text": "And this I have commanded to be done for your salvation, and also for their salvation, in consequence of their being driven out and that which is to come.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 104:52",
+							"text": "The covenants being broken through transgression, by covetousness and feigned words\u2014",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 104:53",
+							"text": "Therefore, you are dissolved as a united order with your brethren, that you are not bound only up to this hour unto them, only on this wise, as I said, by loan as shall be agreed by this order in council, as your circumstances will admit and the voice of the council direct.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 104:54",
+							"text": "And again, a commandment I give unto you concerning your stewardship which I have appointed unto you.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 104:55",
+							"text": "Behold, all these properties are mine, or else your faith is vain, and ye are found hypocrites, and the covenants which ye have made unto me are broken;",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 104:56",
+							"text": "And if the properties are mine, then ye are stewards; otherwise ye are no stewards.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 104:57",
+							"text": "But, verily I say unto you, I have appointed unto you to be stewards over mine house, even stewards indeed.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 104:58",
+							"text": "And for this purpose I have commanded you to organize yourselves, even to print my words, the fulness of my scriptures, the revelations which I have given unto you, and which I shall, hereafter, from time to time give unto you\u2014",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 104:59",
+							"text": "For the purpose of building up my church and kingdom on the earth, and to prepare my people for the time when I shall dwell with them, which is nigh at hand.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 104:60",
+							"text": "And ye shall prepare for yourselves a place for a treasury, and consecrate it unto my name.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 104:61",
+							"text": "And ye shall appoint one among you to keep the treasury, and he shall be ordained unto this blessing.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 104:62",
+							"text": "And there shall be a seal upon the treasury, and all the sacred things shall be delivered into the treasury; and no man among you shall call it his own, or any part of it, for it shall belong to you all with one accord.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 104:63",
+							"text": "And I give it unto you from this very hour; and now see to it, that ye go to and make use of the stewardship which I have appointed unto you, exclusive of the sacred things, for the purpose of printing these sacred things as I have said.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 104:64",
+							"text": "And the avails of the sacred things shall be had in the treasury, and a seal shall be upon it; and it shall not be used or taken out of the treasury by any one, neither shall the seal be loosed which shall be placed upon it, only by the voice of the order, or by commandment.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 104:65",
+							"text": "And thus shall ye preserve the avails of the sacred things in the treasury, for sacred and holy purposes.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 104:66",
+							"text": "And this shall be called the sacred treasury of the Lord; and a seal shall be kept upon it that it may be holy and consecrated unto the Lord.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 104:67",
+							"text": "And again, there shall be another treasury prepared, and a treasurer appointed to keep the treasury, and a seal shall be placed upon it;",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 104:68",
+							"text": "And all moneys that you receive in your stewardships, by improving upon the properties which I have appointed unto you, in houses, or in lands, or in cattle, or in all things save it be the holy and sacred writings, which I have reserved unto myself for holy and sacred purposes, shall be cast into the treasury as fast as you receive moneys, by hundreds, or by fifties, or by twenties, or by tens, or by fives.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 104:69",
+							"text": "Or in other words, if any man among you obtain five dollars let him cast them into the treasury; or if he obtain ten, or twenty, or fifty, or an hundred, let him do likewise;",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 104:70",
+							"text": "And let not any among you say that it is his own; for it shall not be called his, nor any part of it.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 104:71",
+							"text": "And there shall not any part of it be used, or taken out of the treasury, only by the voice and common consent of the order.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 104:72",
+							"text": "And this shall be the voice and common consent of the order\u2014that any man among you say to the treasurer: I have need of this to help me in my stewardship\u2014",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 104:73",
+							"text": "If it be five dollars, or if it be ten dollars, or twenty, or fifty, or a hundred, the treasurer shall give unto him the sum which he requires to help him in his stewardship\u2014",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 104:74",
+							"text": "Until he be found a transgressor, and it is manifest before the council of the order plainly that he is an unfaithful and an unwise steward.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 104:75",
+							"text": "But so long as he is in full fellowship, and is faithful and wise in his stewardship, this shall be his token unto the treasurer that the treasurer shall not withhold.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 104:76",
+							"text": "But in case of transgression, the treasurer shall be subject unto the council and voice of the order.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 104:77",
+							"text": "And in case the treasurer is found an unfaithful and an unwise steward, he shall be subject to the council and voice of the order, and shall be removed out of his place, and another shall be appointed in his stead.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 104:78",
+							"text": "And again, verily I say unto you, concerning your debts\u2014behold it is my will that you shall pay all your debts.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 104:79",
+							"text": "And it is my will that you shall humble yourselves before me, and obtain this blessing by your diligence and humility and the prayer of faith.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 104:80",
+							"text": "And inasmuch as you are diligent and humble, and exercise the prayer of faith, behold, I will soften the hearts of those to whom you are in debt, until I shall send means unto you for your deliverance.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 104:81",
+							"text": "Therefore write speedily to New York and write according to that which shall be dictated by my Spirit; and I will soften the hearts of those to whom you are in debt, that it shall be taken away out of their minds to bring affliction upon you.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 104:82",
+							"text": "And inasmuch as ye are humble and faithful and call upon my name, behold, I will give you the victory.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 104:83",
+							"text": "I give unto you a promise, that you shall be delivered this once out of your bondage.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 104:84",
+							"text": "Inasmuch as you obtain a chance to loan money by hundreds, or thousands, even until you shall loan enough to deliver yourself from bondage, it is your privilege.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 104:85",
+							"text": "And pledge the properties which I have put into your hands, this once, by giving your names by common consent or otherwise, as it shall seem good unto you.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 104:86",
+							"text": "I give unto you this privilege, this once; and behold, if you proceed to do the things which I have laid before you, according to my commandments, all these things are mine, and ye are my stewards, and the master will not suffer his house to be broken up. Even so. Amen.",
+							"verse": 86
+						}
+					]
+				},
+				{
+					"chapter": 105,
+					"reference": "D&C 105",
+					"verses": [{
+							"reference": "D&C 105:1",
+							"text": "Verily I say unto you who have assembled yourselves together that you may learn my will concerning the redemption of mine afflicted people\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 105:2",
+							"text": "Behold, I say unto you, were it not for the transgressions of my people, speaking concerning the church and not individuals, they might have been redeemed even now.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 105:3",
+							"text": "But behold, they have not learned to be obedient to the things which I required at their hands, but are full of all manner of evil, and do not impart of their substance, as becometh saints, to the poor and afflicted among them;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 105:4",
+							"text": "And are not united according to the union required by the law of the celestial kingdom;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 105:5",
+							"text": "And Zion cannot be built up unless it is by the principles of the law of the celestial kingdom; otherwise I cannot receive her unto myself.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 105:6",
+							"text": "And my people must needs be chastened until they learn obedience, if it must needs be, by the things which they suffer.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 105:7",
+							"text": "I speak not concerning those who are appointed to lead my people, who are the first elders of my church, for they are not all under this condemnation;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 105:8",
+							"text": "But I speak concerning my churches abroad\u2014there are many who will say: Where is their God? Behold, he will deliver them in time of trouble, otherwise we will not go up unto Zion, and will keep our moneys.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 105:9",
+							"text": "Therefore, in consequence of the transgressions of my people, it is expedient in me that mine elders should wait for a little season for the redemption of Zion\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 105:10",
+							"text": "That they themselves may be prepared, and that my people may be taught more perfectly, and have experience, and know more perfectly concerning their duty, and the things which I require at their hands.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 105:11",
+							"text": "And this cannot be brought to pass until mine elders are endowed with power from on high.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 105:12",
+							"text": "For behold, I have prepared a great endowment and blessing to be poured out upon them, inasmuch as they are faithful and continue in humility before me.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 105:13",
+							"text": "Therefore it is expedient in me that mine elders should wait for a little season, for the redemption of Zion.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 105:14",
+							"text": "For behold, I do not require at their hands to fight the battles of Zion; for, as I said in a former commandment, even so will I fulfil\u2014I will fight your battles.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 105:15",
+							"text": "Behold, the destroyer I have sent forth to destroy and lay waste mine enemies; and not many years hence they shall not be left to pollute mine heritage, and to blaspheme my name upon the lands which I have consecrated for the gathering together of my saints.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 105:16",
+							"text": "Behold, I have commanded my servant Joseph Smith, Jun., to say unto the strength of my house, even my warriors, my young men, and middle-aged, to gather together for the redemption of my people, and throw down the towers of mine enemies, and scatter their watchmen;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 105:17",
+							"text": "But the strength of mine house have not hearkened unto my words.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 105:18",
+							"text": "But inasmuch as there are those who have hearkened unto my words, I have prepared a blessing and an endowment for them, if they continue faithful.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 105:19",
+							"text": "I have heard their prayers, and will accept their offering; and it is expedient in me that they should be brought thus far for a trial of their faith.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 105:20",
+							"text": "And now, verily I say unto you, a commandment I give unto you, that as many as have come up hither, that can stay in the region round about, let them stay;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 105:21",
+							"text": "And those that cannot stay, who have families in the east, let them tarry for a little season, inasmuch as my servant Joseph shall appoint unto them;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 105:22",
+							"text": "For I will counsel him concerning this matter, and all things whatsoever he shall appoint unto them shall be fulfilled.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 105:23",
+							"text": "And let all my people who dwell in the regions round about be very faithful, and prayerful, and humble before me, and reveal not the things which I have revealed unto them, until it is wisdom in me that they should be revealed.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 105:24",
+							"text": "Talk not of judgments, neither boast of faith nor of mighty works, but carefully gather together, as much in one region as can be, consistently with the feelings of the people;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 105:25",
+							"text": "And behold, I will give unto you favor and grace in their eyes, that you may rest in peace and safety, while you are saying unto the people: Execute judgment and justice for us according to law, and redress us of our wrongs.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 105:26",
+							"text": "Now, behold, I say unto you, my friends, in this way you may find favor in the eyes of the people, until the army of Israel becomes very great.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 105:27",
+							"text": "And I will soften the hearts of the people, as I did the heart of Pharaoh, from time to time, until my servant Joseph Smith, Jun., and mine elders, whom I have appointed, shall have time to gather up the strength of my house,",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 105:28",
+							"text": "And to have sent wise men, to fulfil that which I have commanded concerning the purchasing of all the lands in Jackson county that can be purchased, and in the adjoining counties round about.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 105:29",
+							"text": "For it is my will that these lands should be purchased; and after they are purchased that my saints should possess them according to the laws of consecration which I have given.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 105:30",
+							"text": "And after these lands are purchased, I will hold the armies of Israel guiltless in taking possession of their own lands, which they have previously purchased with their moneys, and of throwing down the towers of mine enemies that may be upon them, and scattering their watchmen, and avenging me of mine enemies unto the third and fourth generation of them that hate me.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 105:31",
+							"text": "But first let my army become very great, and let it be sanctified before me, that it may become fair as the sun, and clear as the moon, and that her banners may be terrible unto all nations;",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 105:32",
+							"text": "That the kingdoms of this world may be constrained to acknowledge that the kingdom of Zion is in very deed the kingdom of our God and his Christ; therefore, let us become subject unto her laws.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 105:33",
+							"text": "Verily I say unto you, it is expedient in me that the first elders of my church should receive their endowment from on high in my house, which I have commanded to be built unto my name in the land of Kirtland.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 105:34",
+							"text": "And let those commandments which I have given concerning Zion and her law be executed and fulfilled, after her redemption.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 105:35",
+							"text": "There has been a day of calling, but the time has come for a day of choosing; and let those be chosen that are worthy.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 105:36",
+							"text": "And it shall be manifest unto my servant, by the voice of the Spirit, those that are chosen; and they shall be sanctified;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 105:37",
+							"text": "And inasmuch as they follow the counsel which they receive, they shall have power after many days to accomplish all things pertaining to Zion.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 105:38",
+							"text": "And again I say unto you, sue for peace, not only to the people that have smitten you, but also to all people;",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 105:39",
+							"text": "And lift up an ensign of peace, and make a proclamation of peace unto the ends of the earth;",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 105:40",
+							"text": "And make proposals for peace unto those who have smitten you, according to the voice of the Spirit which is in you, and all things shall work together for your good.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 105:41",
+							"text": "Therefore, be faithful; and behold, and lo, I am with you even unto the end. Even so. Amen.",
+							"verse": 41
+						}
+					]
+				},
+				{
+					"chapter": 106,
+					"reference": "D&C 106",
+					"verses": [{
+							"reference": "D&C 106:1",
+							"text": "It is my will that my servant Warren A. Cowdery should be appointed and ordained a presiding high priest over my church, in the land of Freedom and the regions round about;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 106:2",
+							"text": "And should preach my everlasting gospel, and lift up his voice and warn the people, not only in his own place, but in the adjoining counties;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 106:3",
+							"text": "And devote his whole time to this high and holy calling, which I now give unto him, seeking diligently the kingdom of heaven and its righteousness, and all things necessary shall be added thereunto; for the laborer is worthy of his hire.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 106:4",
+							"text": "And again, verily I say unto you, the coming of the Lord draweth nigh, and it overtaketh the world as a thief in the night\u2014",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 106:5",
+							"text": "Therefore, gird up your loins, that you may be the children of light, and that day shall not overtake you as a thief.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 106:6",
+							"text": "And again, verily I say unto you, there was joy in heaven when my servant Warren bowed to my scepter, and separated himself from the crafts of men;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 106:7",
+							"text": "Therefore, blessed is my servant Warren, for I will have mercy on him; and, notwithstanding the vanity of his heart, I will lift him up inasmuch as he will humble himself before me.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 106:8",
+							"text": "And I will give him grace and assurance wherewith he may stand; and if he continue to be a faithful witness and a light unto the church I have prepared a crown for him in the mansions of my Father. Even so. Amen.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 107,
+					"reference": "D&C 107",
+					"verses": [{
+							"reference": "D&C 107:1",
+							"text": "There are, in the church, two priesthoods, namely, the Melchizedek and Aaronic, including the Levitical Priesthood.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 107:2",
+							"text": "Why the first is called the Melchizedek Priesthood is because Melchizedek was such a great high priest.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 107:3",
+							"text": "Before his day it was called the Holy Priesthood, after the Order of the Son of God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 107:4",
+							"text": "But out of respect or reverence to the name of the Supreme Being, to avoid the too frequent repetition of his name, they, the church, in ancient days, called that priesthood after Melchizedek, or the Melchizedek Priesthood.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 107:5",
+							"text": "All other authorities or offices in the church are appendages to this priesthood.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 107:6",
+							"text": "But there are two divisions or grand heads\u2014one is the Melchizedek Priesthood, and the other is the Aaronic or Levitical Priesthood.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 107:7",
+							"text": "The office of an elder comes under the priesthood of Melchizedek.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 107:8",
+							"text": "The Melchizedek Priesthood holds the right of presidency, and has power and authority over all the offices in the church in all ages of the world, to administer in spiritual things.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 107:9",
+							"text": "The Presidency of the High Priesthood, after the order of Melchizedek, have a right to officiate in all the offices in the church.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 107:10",
+							"text": "High priests after the order of the Melchizedek Priesthood have a right to officiate in their own standing, under the direction of the presidency, in administering spiritual things, and also in the office of an elder, priest (of the Levitical order), teacher, deacon, and member.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 107:11",
+							"text": "An elder has a right to officiate in his stead when the high priest is not present.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 107:12",
+							"text": "The high priest and elder are to administer in spiritual things, agreeable to the covenants and commandments of the church; and they have a right to officiate in all these offices of the church when there are no higher authorities present.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 107:13",
+							"text": "The second priesthood is called the Priesthood of Aaron, because it was conferred upon Aaron and his seed, throughout all their generations.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 107:14",
+							"text": "Why it is called the lesser priesthood is because it is an appendage to the greater, or the Melchizedek Priesthood, and has power in administering outward ordinances.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 107:15",
+							"text": "The bishopric is the presidency of this priesthood, and holds the keys or authority of the same.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 107:16",
+							"text": "No man has a legal right to this office, to hold the keys of this priesthood, except he be a literal descendant of Aaron.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 107:17",
+							"text": "But as a high priest of the Melchizedek Priesthood has authority to officiate in all the lesser offices, he may officiate in the office of bishop when no literal descendant of Aaron can be found, provided he is called and set apart and ordained unto this power by the hands of the Presidency of the Melchizedek Priesthood.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 107:18",
+							"text": "The power and authority of the higher, or Melchizedek Priesthood, is to hold the keys of all the spiritual blessings of the church\u2014",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 107:19",
+							"text": "To have the privilege of receiving the mysteries of the kingdom of heaven, to have the heavens opened unto them, to commune with the general assembly and church of the Firstborn, and to enjoy the communion and presence of God the Father, and Jesus the mediator of the new covenant.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 107:20",
+							"text": "The power and authority of the lesser, or Aaronic Priesthood, is to hold the keys of the ministering of angels, and to administer in outward ordinances, the letter of the gospel, the baptism of repentance for the remission of sins, agreeable to the covenants and commandments.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 107:21",
+							"text": "Of necessity there are presidents, or presiding officers growing out of, or appointed of or from among those who are ordained to the several offices in these two priesthoods.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 107:22",
+							"text": "Of the Melchizedek Priesthood, three Presiding High Priests, chosen by the body, appointed and ordained to that office, and upheld by the confidence, faith, and prayer of the church, form a quorum of the Presidency of the Church.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 107:23",
+							"text": "The twelve traveling councilors are called to be the Twelve Apostles, or special witnesses of the name of Christ in all the world\u2014thus differing from other officers in the church in the duties of their calling.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 107:24",
+							"text": "And they form a quorum, equal in authority and power to the three presidents previously mentioned.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 107:25",
+							"text": "The Seventy are also called to preach the gospel, and to be especial witnesses unto the Gentiles and in all the world\u2014thus differing from other officers in the church in the duties of their calling.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 107:26",
+							"text": "And they form a quorum, equal in authority to that of the Twelve special witnesses or Apostles just named.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 107:27",
+							"text": "And every decision made by either of these quorums must be by the unanimous voice of the same; that is, every member in each quorum must be agreed to its decisions, in order to make their decisions of the same power or validity one with the other\u2014",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 107:28",
+							"text": "A majority may form a quorum when circumstances render it impossible to be otherwise\u2014",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 107:29",
+							"text": "Unless this is the case, their decisions are not entitled to the same blessings which the decisions of a quorum of three presidents were anciently, who were ordained after the order of Melchizedek, and were righteous and holy men.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 107:30",
+							"text": "The decisions of these quorums, or either of them, are to be made in all righteousness, in holiness, and lowliness of heart, meekness and long-suffering, and in faith, and virtue, and knowledge, temperance, patience, godliness, brotherly kindness and charity;",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 107:31",
+							"text": "Because the promise is, if these things abound in them they shall not be unfruitful in the knowledge of the Lord.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 107:32",
+							"text": "And in case that any decision of these quorums is made in unrighteousness, it may be brought before a general assembly of the several quorums, which constitute the spiritual authorities of the church; otherwise there can be no appeal from their decision.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 107:33",
+							"text": "The Twelve are a Traveling Presiding High Council, to officiate in the name of the Lord, under the direction of the Presidency of the Church, agreeable to the institution of heaven; to build up the church, and regulate all the affairs of the same in all nations, first unto the Gentiles and secondly unto the Jews.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 107:34",
+							"text": "The Seventy are to act in the name of the Lord, under the direction of the Twelve or the traveling high council, in building up the church and regulating all the affairs of the same in all nations, first unto the Gentiles and then to the Jews\u2014",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 107:35",
+							"text": "The Twelve being sent out, holding the keys, to open the door by the proclamation of the gospel of Jesus Christ, and first unto the Gentiles and then unto the Jews.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 107:36",
+							"text": "The standing high councils, at the stakes of Zion, form a quorum equal in authority in the affairs of the church, in all their decisions, to the quorum of the presidency, or to the traveling high council.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 107:37",
+							"text": "The high council in Zion form a quorum equal in authority in the affairs of the church, in all their decisions, to the councils of the Twelve at the stakes of Zion.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 107:38",
+							"text": "It is the duty of the traveling high council to call upon the Seventy, when they need assistance, to fill the several calls for preaching and administering the gospel, instead of any others.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 107:39",
+							"text": "It is the duty of the Twelve, in all large branches of the church, to ordain evangelical ministers, as they shall be designated unto them by revelation\u2014",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 107:40",
+							"text": "The order of this priesthood was confirmed to be handed down from father to son, and rightly belongs to the literal descendants of the chosen seed, to whom the promises were made.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 107:41",
+							"text": "This order was instituted in the days of Adam, and came down by lineage in the following manner:",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 107:42",
+							"text": "From Adam to Seth, who was ordained by Adam at the age of sixty-nine years, and was blessed by him three years previous to his (Adam's) death, and received the promise of God by his father, that his posterity should be the chosen of the Lord, and that they should be preserved unto the end of the earth;",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 107:43",
+							"text": "Because he (Seth) was a perfect man, and his likeness was the express likeness of his father, insomuch that he seemed to be like unto his father in all things, and could be distinguished from him only by his age.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 107:44",
+							"text": "Enos was ordained at the age of one hundred and thirty-four years and four months, by the hand of Adam.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 107:45",
+							"text": "God called upon Cainan in the wilderness in the fortieth year of his age; and he met Adam in journeying to the place Shedolamak. He was eighty-seven years old when he received his ordination.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 107:46",
+							"text": "Mahalaleel was four hundred and ninety-six years and seven days old when he was ordained by the hand of Adam, who also blessed him.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 107:47",
+							"text": "Jared was two hundred years old when he was ordained under the hand of Adam, who also blessed him.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 107:48",
+							"text": "Enoch was twenty-five years old when he was ordained under the hand of Adam; and he was sixty-five and Adam blessed him.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 107:49",
+							"text": "And he saw the Lord, and he walked with him, and was before his face continually; and he walked with God three hundred and sixty-five years, making him four hundred and thirty years old when he was translated.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 107:50",
+							"text": "Methuselah was one hundred years old when he was ordained under the hand of Adam.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 107:51",
+							"text": "Lamech was thirty-two years old when he was ordained under the hand of Seth.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 107:52",
+							"text": "Noah was ten years old when he was ordained under the hand of Methuselah.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 107:53",
+							"text": "Three years previous to the death of Adam, he called Seth, Enos, Cainan, Mahalaleel, Jared, Enoch, and Methuselah, who were all high priests, with the residue of his posterity who were righteous, into the valley of Adam-ondi-Ahman, and there bestowed upon them his last blessing.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 107:54",
+							"text": "And the Lord appeared unto them, and they rose up and blessed Adam, and called him Michael, the prince, the archangel.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 107:55",
+							"text": "And the Lord administered comfort unto Adam, and said unto him: I have set thee to be at the head; a multitude of nations shall come of thee, and thou art a prince over them forever.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 107:56",
+							"text": "And Adam stood up in the midst of the congregation; and, notwithstanding he was bowed down with age, being full of the Holy Ghost, predicted whatsoever should befall his posterity unto the latest generation.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 107:57",
+							"text": "These things were all written in the book of Enoch, and are to be testified of in due time.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 107:58",
+							"text": "It is the duty of the Twelve, also, to ordain and set in order all the other officers of the church, agreeable to the revelation which says:",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 107:59",
+							"text": "To the church of Christ in the land of Zion, in addition to the church laws respecting church business\u2014",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 107:60",
+							"text": "Verily, I say unto you, saith the Lord of Hosts, there must needs be presiding elders to preside over those who are of the office of an elder;",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 107:61",
+							"text": "And also priests to preside over those who are of the office of a priest;",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 107:62",
+							"text": "And also teachers to preside over those who are of the office of a teacher, in like manner, and also the deacons\u2014",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 107:63",
+							"text": "Wherefore, from deacon to teacher, and from teacher to priest, and from priest to elder, severally as they are appointed, according to the covenants and commandments of the church.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 107:64",
+							"text": "Then comes the High Priesthood, which is the greatest of all.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 107:65",
+							"text": "Wherefore, it must needs be that one be appointed of the High Priesthood to preside over the priesthood, and he shall be called President of the High Priesthood of the Church;",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 107:66",
+							"text": "Or, in other words, the Presiding High Priest over the High Priesthood of the Church.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 107:67",
+							"text": "From the same comes the administering of ordinances and blessings upon the church, by the laying on of the hands.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 107:68",
+							"text": "Wherefore, the office of a bishop is not equal unto it; for the office of a bishop is in administering all temporal things;",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 107:69",
+							"text": "Nevertheless a bishop must be chosen from the High Priesthood, unless he is a literal descendant of Aaron;",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 107:70",
+							"text": "For unless he is a literal descendant of Aaron he cannot hold the keys of that priesthood.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 107:71",
+							"text": "Nevertheless, a high priest, that is, after the order of Melchizedek, may be set apart unto the ministering of temporal things, having a knowledge of them by the Spirit of truth;",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 107:72",
+							"text": "And also to be a judge in Israel, to do the business of the church, to sit in judgment upon transgressors upon testimony as it shall be laid before him according to the laws, by the assistance of his counselors, whom he has chosen or will choose among the elders of the church.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 107:73",
+							"text": "This is the duty of a bishop who is not a literal descendant of Aaron, but has been ordained to the High Priesthood after the order of Melchizedek.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 107:74",
+							"text": "Thus shall he be a judge, even a common judge among the inhabitants of Zion, or in a stake of Zion, or in any branch of the church where he shall be set apart unto this ministry, until the borders of Zion are enlarged and it becomes necessary to have other bishops or judges in Zion or elsewhere.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 107:75",
+							"text": "And inasmuch as there are other bishops appointed they shall act in the same office.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 107:76",
+							"text": "But a literal descendant of Aaron has a legal right to the presidency of this priesthood, to the keys of this ministry, to act in the office of bishop independently, without counselors, except in a case where a President of the High Priesthood, after the order of Melchizedek, is tried, to sit as a judge in Israel.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 107:77",
+							"text": "And the decision of either of these councils, agreeable to the commandment which says:",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 107:78",
+							"text": "Again, verily, I say unto you, the most important business of the church, and the most difficult cases of the church, inasmuch as there is not satisfaction upon the decision of the bishop or judges, it shall be handed over and carried up unto the council of the church, before the Presidency of the High Priesthood.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 107:79",
+							"text": "And the Presidency of the council of the High Priesthood shall have power to call other high priests, even twelve, to assist as counselors; and thus the Presidency of the High Priesthood and its counselors shall have power to decide upon testimony according to the laws of the church.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 107:80",
+							"text": "And after this decision it shall be had in remembrance no more before the Lord; for this is the highest council of the church of God, and a final decision upon controversies in spiritual matters.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 107:81",
+							"text": "There is not any person belonging to the church who is exempt from this council of the church.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 107:82",
+							"text": "And inasmuch as a President of the High Priesthood shall transgress, he shall be had in remembrance before the common council of the church, who shall be assisted by twelve counselors of the High Priesthood;",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 107:83",
+							"text": "And their decision upon his head shall be an end of controversy concerning him.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 107:84",
+							"text": "Thus, none shall be exempted from the justice and the laws of God, that all things may be done in order and in solemnity before him, according to truth and righteousness.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 107:85",
+							"text": "And again, verily I say unto you, the duty of a president over the office of a deacon is to preside over twelve deacons, to sit in council with them, and to teach them their duty, edifying one another, as it is given according to the covenants.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 107:86",
+							"text": "And also the duty of the president over the office of the teachers is to preside over twenty-four of the teachers, and to sit in council with them, teaching them the duties of their office, as given in the covenants.",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 107:87",
+							"text": "Also the duty of the president over the Priesthood of Aaron is to preside over forty-eight priests, and sit in council with them, to teach them the duties of their office, as is given in the covenants\u2014",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 107:88",
+							"text": "This president is to be a bishop; for this is one of the duties of this priesthood.",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 107:89",
+							"text": "Again, the duty of the president over the office of elders is to preside over ninety-six elders, and to sit in council with them, and to teach them according to the covenants.",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 107:90",
+							"text": "This presidency is a distinct one from that of the seventy, and is designed for those who do not travel into all the world.",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 107:91",
+							"text": "And again, the duty of the President of the office of the High Priesthood is to preside over the whole church, and to be like unto Moses\u2014",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 107:92",
+							"text": "Behold, here is wisdom; yea, to be a seer, a revelator, a translator, and a prophet, having all the gifts of God which he bestows upon the head of the church.",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 107:93",
+							"text": "And it is according to the vision showing the order of the Seventy, that they should have seven presidents to preside over them, chosen out of the number of the seventy;",
+							"verse": 93
+						},
+						{
+							"reference": "D&C 107:94",
+							"text": "And the seventh president of these presidents is to preside over the six;",
+							"verse": 94
+						},
+						{
+							"reference": "D&C 107:95",
+							"text": "And these seven presidents are to choose other seventy besides the first seventy to whom they belong, and are to preside over them;",
+							"verse": 95
+						},
+						{
+							"reference": "D&C 107:96",
+							"text": "And also other seventy, until seven times seventy, if the labor in the vineyard of necessity requires it.",
+							"verse": 96
+						},
+						{
+							"reference": "D&C 107:97",
+							"text": "And these seventy are to be traveling ministers, unto the Gentiles first and also unto the Jews.",
+							"verse": 97
+						},
+						{
+							"reference": "D&C 107:98",
+							"text": "Whereas other officers of the church, who belong not unto the Twelve, neither to the Seventy, are not under the responsibility to travel among all nations, but are to travel as their circumstances shall allow, notwithstanding they may hold as high and responsible offices in the church.",
+							"verse": 98
+						},
+						{
+							"reference": "D&C 107:99",
+							"text": "Wherefore, now let every man learn his duty, and to act in the office in which he is appointed, in all diligence.",
+							"verse": 99
+						},
+						{
+							"reference": "D&C 107:100",
+							"text": "He that is slothful shall not be counted worthy to stand, and he that learns not his duty and shows himself not approved shall not be counted worthy to stand. Even so. Amen.",
+							"verse": 100
+						}
+					]
+				},
+				{
+					"chapter": 108,
+					"reference": "D&C 108",
+					"verses": [{
+							"reference": "D&C 108:1",
+							"text": "Verily thus saith the Lord unto you, my servant Lyman: Your sins are forgiven you, because you have obeyed my voice in coming up hither this morning to receive counsel of him whom I have appointed.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 108:2",
+							"text": "Therefore, let your soul be at rest concerning your spiritual standing, and resist no more my voice.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 108:3",
+							"text": "And arise up and be more careful henceforth in observing your vows, which you have made and do make, and you shall be blessed with exceeding great blessings.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 108:4",
+							"text": "Wait patiently until the solemn assembly shall be called of my servants, then you shall be remembered with the first of mine elders, and receive right by ordination with the rest of mine elders whom I have chosen.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 108:5",
+							"text": "Behold, this is the promise of the Father unto you if you continue faithful.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 108:6",
+							"text": "And it shall be fulfilled upon you in that day that you shall have right to preach my gospel wheresoever I shall send you, from henceforth from that time.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 108:7",
+							"text": "Therefore, strengthen your brethren in all your conversation, in all your prayers, in all your exhortations, and in all your doings.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 108:8",
+							"text": "And behold, and lo, I am with you to bless you and deliver you forever. Amen.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 109,
+					"reference": "D&C 109",
+					"verses": [{
+							"reference": "D&C 109:1",
+							"text": "Thanks be to thy name, O Lord God of Israel, who keepest covenant and showest mercy unto thy servants who walk uprightly before thee, with all their hearts\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 109:2",
+							"text": "Thou who hast commanded thy servants to build a house to thy name in this place [Kirtland].",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 109:3",
+							"text": "And now thou beholdest, O Lord, that thy servants have done according to thy commandment.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 109:4",
+							"text": "And now we ask thee, Holy Father, in the name of Jesus Christ, the Son of thy bosom, in whose name alone salvation can be administered to the children of men, we ask thee, O Lord, to accept of this house, the workmanship of the hands of us, thy servants, which thou didst command us to build.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 109:5",
+							"text": "For thou knowest that we have done this work through great tribulation; and out of our poverty we have given of our substance to build a house to thy name, that the Son of Man might have a place to manifest himself to his people.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 109:6",
+							"text": "And as thou hast said in a revelation, given to us, calling us thy friends, saying\u2014Call your solemn assembly, as I have commanded you;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 109:7",
+							"text": "And as all have not faith, seek ye diligently and teach one another words of wisdom; yea, seek ye out of the best books words of wisdom, seek learning even by study and also by faith;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 109:8",
+							"text": "Organize yourselves; prepare every needful thing, and establish a house, even a house of prayer, a house of fasting, a house of faith, a house of learning, a house of glory, a house of order, a house of God;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 109:9",
+							"text": "That your incomings may be in the name of the Lord, that your outgoings may be in the name of the Lord, that all your salutations may be in the name of the Lord, with uplifted hands unto the Most High\u2014",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 109:10",
+							"text": "And now, Holy Father, we ask thee to assist us, thy people, with thy grace, in calling our solemn assembly, that it may be done to thine honor and to thy divine acceptance;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 109:11",
+							"text": "And in a manner that we may be found worthy, in thy sight, to secure a fulfilment of the promises which thou hast made unto us, thy people, in the revelations given unto us;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 109:12",
+							"text": "That thy glory may rest down upon thy people, and upon this thy house, which we now dedicate to thee, that it may be sanctified and consecrated to be holy, and that thy holy presence may be continually in this house;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 109:13",
+							"text": "And that all people who shall enter upon the threshold of the Lord's house may feel thy power, and feel constrained to acknowledge that thou hast sanctified it, and that it is thy house, a place of thy holiness.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 109:14",
+							"text": "And do thou grant, Holy Father, that all those who shall worship in this house may be taught words of wisdom out of the best books, and that they may seek learning even by study, and also by faith, as thou hast said;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 109:15",
+							"text": "And that they may grow up in thee, and receive a fulness of the Holy Ghost, and be organized according to thy laws, and be prepared to obtain every needful thing;",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 109:16",
+							"text": "And that this house may be a house of prayer, a house of fasting, a house of faith, a house of glory and of God, even thy house;",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 109:17",
+							"text": "That all the incomings of thy people, into this house, may be in the name of the Lord;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 109:18",
+							"text": "That all their outgoings from this house may be in the name of the Lord;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 109:19",
+							"text": "And that all their salutations may be in the name of the Lord, with holy hands, uplifted to the Most High;",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 109:20",
+							"text": "And that no unclean thing shall be permitted to come into thy house to pollute it;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 109:21",
+							"text": "And when thy people transgress, any of them, they may speedily repent and return unto thee, and find favor in thy sight, and be restored to the blessings which thou hast ordained to be poured out upon those who shall reverence thee in thy house.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 109:22",
+							"text": "And we ask thee, Holy Father, that thy servants may go forth from this house armed with thy power, and that thy name may be upon them, and thy glory be round about them, and thine angels have charge over them;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 109:23",
+							"text": "And from this place they may bear exceedingly great and glorious tidings, in truth, unto the ends of the earth, that they may know that this is thy work, and that thou hast put forth thy hand, to fulfil that which thou hast spoken by the mouths of the prophets, concerning the last days.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 109:24",
+							"text": "We ask thee, Holy Father, to establish the people that shall worship, and honorably hold a name and standing in this thy house, to all generations and for eternity;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 109:25",
+							"text": "That no weapon formed against them shall prosper; that he who diggeth a pit for them shall fall into the same himself;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 109:26",
+							"text": "That no combination of wickedness shall have power to rise up and prevail over thy people upon whom thy name shall be put in this house;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 109:27",
+							"text": "And if any people shall rise against this people, that thine anger be kindled against them;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 109:28",
+							"text": "And if they shall smite this people thou wilt smite them; thou wilt fight for thy people as thou didst in the day of battle, that they may be delivered from the hands of all their enemies.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 109:29",
+							"text": "We ask thee, Holy Father, to confound, and astonish, and to bring to shame and confusion, all those who have spread lying reports abroad, over the world, against thy servant or servants, if they will not repent, when the everlasting gospel shall be proclaimed in their ears;",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 109:30",
+							"text": "And that all their works may be brought to naught, and be swept away by the hail, and by the judgments which thou wilt send upon them in thine anger, that there may be an end to lyings and slanders against thy people.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 109:31",
+							"text": "For thou knowest, O Lord, that thy servants have been innocent before thee in bearing record of thy name, for which they have suffered these things.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 109:32",
+							"text": "Therefore we plead before thee for a full and complete deliverance from under this yoke;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 109:33",
+							"text": "Break it off, O Lord; break it off from the necks of thy servants, by thy power, that we may rise up in the midst of this generation and do thy work.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 109:34",
+							"text": "O Jehovah, have mercy upon this people, and as all men sin, forgive the transgressions of thy people, and let them be blotted out forever.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 109:35",
+							"text": "Let the anointing of thy ministers be sealed upon them with power from on high.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 109:36",
+							"text": "Let it be fulfilled upon them, as upon those on the day of Pentecost; let the gift of tongues be poured out upon thy people, even cloven tongues as of fire, and the interpretation thereof.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 109:37",
+							"text": "And let thy house be filled, as with a rushing mighty wind, with thy glory.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 109:38",
+							"text": "Put upon thy servants the testimony of the covenant, that when they go out and proclaim thy word they may seal up the law, and prepare the hearts of thy saints for all those judgments thou art about to send, in thy wrath, upon the inhabitants of the earth, because of their transgressions, that thy people may not faint in the day of trouble.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 109:39",
+							"text": "And whatsoever city thy servants shall enter, and the people of that city receive their testimony, let thy peace and thy salvation be upon that city; that they may gather out of that city the righteous, that they may come forth to Zion, or to her stakes, the places of thine appointment, with songs of everlasting joy;",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 109:40",
+							"text": "And until this be accomplished, let not thy judgments fall upon that city.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 109:41",
+							"text": "And whatsoever city thy servants shall enter, and the people of that city receive not the testimony of thy servants, and thy servants warn them to save themselves from this untoward generation, let it be upon that city according to that which thou hast spoken by the mouths of thy prophets.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 109:42",
+							"text": "But deliver thou, O Jehovah, we beseech thee, thy servants from their hands, and cleanse them from their blood.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 109:43",
+							"text": "O Lord, we delight not in the destruction of our fellow men; their souls are precious before thee;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 109:44",
+							"text": "But thy word must be fulfilled. Help thy servants to say, with thy grace assisting them: Thy will be done, O Lord, and not ours.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 109:45",
+							"text": "We know that thou hast spoken by the mouth of thy prophets terrible things concerning the wicked, in the last days\u2014that thou wilt pour out thy judgments, without measure;",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 109:46",
+							"text": "Therefore, O Lord, deliver thy people from the calamity of the wicked; enable thy servants to seal up the law, and bind up the testimony, that they may be prepared against the day of burning.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 109:47",
+							"text": "We ask thee, Holy Father, to remember those who have been driven by the inhabitants of Jackson county, Missouri, from the lands of their inheritance, and break off, O Lord, this yoke of affliction that has been put upon them.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 109:48",
+							"text": "Thou knowest, O Lord, that they have been greatly oppressed and afflicted by wicked men; and our hearts flow out with sorrow because of their grievous burdens.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 109:49",
+							"text": "O Lord, how long wilt thou suffer this people to bear this affliction, and the cries of their innocent ones to ascend up in thine ears, and their blood come up in testimony before thee, and not make a display of thy testimony in their behalf?",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 109:50",
+							"text": "Have mercy, O Lord, upon the wicked mob, who have driven thy people, that they may cease to spoil, that they may repent of their sins if repentance is to be found;",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 109:51",
+							"text": "But if they will not, make bare thine arm, O Lord, and redeem that which thou didst appoint a Zion unto thy people.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 109:52",
+							"text": "And if it cannot be otherwise, that the cause of thy people may not fail before thee may thine anger be kindled, and thine indignation fall upon them, that they may be wasted away, both root and branch, from under heaven;",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 109:53",
+							"text": "But inasmuch as they will repent, thou art gracious and merciful, and wilt turn away thy wrath when thou lookest upon the face of thine Anointed.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 109:54",
+							"text": "Have mercy, O Lord, upon all the nations of the earth; have mercy upon the rulers of our land; may those principles, which were so honorably and nobly defended, namely, the Constitution of our land, by our fathers, be established forever.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 109:55",
+							"text": "Remember the kings, the princes, the nobles, and the great ones of the earth, and all people, and the churches, all the poor, the needy, and afflicted ones of the earth;",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 109:56",
+							"text": "That their hearts may be softened when thy servants shall go out from thy house, O Jehovah, to bear testimony of thy name; that their prejudices may give way before the truth, and thy people may obtain favor in the sight of all;",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 109:57",
+							"text": "That all the ends of the earth may know that we, thy servants, have heard thy voice, and that thou hast sent us;",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 109:58",
+							"text": "That from among all these, thy servants, the sons of Jacob, may gather out the righteous to build a holy city to thy name, as thou hast commanded them.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 109:59",
+							"text": "We ask thee to appoint unto Zion other stakes besides this one which thou hast appointed, that the gathering of thy people may roll on in great power and majesty, that thy work may be cut short in righteousness.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 109:60",
+							"text": "Now these words, O Lord, we have spoken before thee, concerning the revelations and commandments which thou hast given unto us, who are identified with the Gentiles.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 109:61",
+							"text": "But thou knowest that thou hast a great love for the children of Jacob, who have been scattered upon the mountains for a long time, in a cloudy and dark day.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 109:62",
+							"text": "We therefore ask thee to have mercy upon the children of Jacob, that Jerusalem, from this hour, may begin to be redeemed;",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 109:63",
+							"text": "And the yoke of bondage may begin to be broken off from the house of David;",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 109:64",
+							"text": "And the children of Judah may begin to return to the lands which thou didst give to Abraham, their father.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 109:65",
+							"text": "And cause that the remnants of Jacob, who have been cursed and smitten because of their transgression, be converted from their wild and savage condition to the fulness of the everlasting gospel;",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 109:66",
+							"text": "That they may lay down their weapons of bloodshed, and cease their rebellions.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 109:67",
+							"text": "And may all the scattered remnants of Israel, who have been driven to the ends of the earth, come to a knowledge of the truth, believe in the Messiah, and be redeemed from oppression, and rejoice before thee.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 109:68",
+							"text": "O Lord, remember thy servant, Joseph Smith, Jun., and all his afflictions and persecutions\u2014how he has covenanted with Jehovah, and vowed to thee, O Mighty God of Jacob\u2014and the commandments which thou hast given unto him, and that he hath sincerely striven to do thy will.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 109:69",
+							"text": "Have mercy, O Lord, upon his wife and children, that they may be exalted in thy presence, and preserved by thy fostering hand.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 109:70",
+							"text": "Have mercy upon all their immediate connections, that their prejudices may be broken up and swept away as with a flood; that they may be converted and redeemed with Israel, and know that thou art God.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 109:71",
+							"text": "Remember, O Lord, the presidents, even all the presidents of thy church, that thy right hand may exalt them, with all their families, and their immediate connections, that their names may be perpetuated and had in everlasting remembrance from generation to generation.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 109:72",
+							"text": "Remember all thy church, O Lord, with all their families, and all their immediate connections, with all their sick and afflicted ones, with all the poor and meek of the earth; that the kingdom, which thou hast set up without hands, may become a great mountain and fill the whole earth;",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 109:73",
+							"text": "That thy church may come forth out of the wilderness of darkness, and shine forth fair as the moon, clear as the sun, and terrible as an army with banners;",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 109:74",
+							"text": "And be adorned as a bride for that day when thou shalt unveil the heavens, and cause the mountains to flow down at thy presence, and the valleys to be exalted, the rough places made smooth; that thy glory may fill the earth;",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 109:75",
+							"text": "That when the trump shall sound for the dead, we shall be caught up in the cloud to meet thee, that we may ever be with the Lord;",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 109:76",
+							"text": "That our garments may be pure, that we may be clothed upon with robes of righteousness, with palms in our hands, and crowns of glory upon our heads, and reap eternal joy for all our sufferings.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 109:77",
+							"text": "O Lord God Almighty, hear us in these our petitions, and answer us from heaven, thy holy habitation, where thou sittest enthroned, with glory, honor, power, majesty, might, dominion, truth, justice, judgment, mercy, and an infinity of fulness, from everlasting to everlasting.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 109:78",
+							"text": "O hear, O hear, O hear us, O Lord! And answer these petitions, and accept the dedication of this house unto thee, the work of our hands, which we have built unto thy name;",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 109:79",
+							"text": "And also this church, to put upon it thy name. And help us by the power of thy Spirit, that we may mingle our voices with those bright, shining seraphs around thy throne, with acclamations of praise, singing Hosanna to God and the Lamb!",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 109:80",
+							"text": "And let these, thine anointed ones, be clothed with salvation, and thy saints shout aloud for joy. Amen, and Amen.",
+							"verse": 80
+						}
+					]
+				},
+				{
+					"chapter": 110,
+					"reference": "D&C 110",
+					"verses": [{
+							"reference": "D&C 110:1",
+							"text": "The veil was taken from our minds, and the eyes of our understanding were opened.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 110:2",
+							"text": "We saw the Lord standing upon the breastwork of the pulpit, before us; and under his feet was a paved work of pure gold, in color like amber.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 110:3",
+							"text": "His eyes were as a flame of fire; the hair of his head was white like the pure snow; his countenance shone above the brightness of the sun; and his voice was as the sound of the rushing of great waters, even the voice of Jehovah, saying:",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 110:4",
+							"text": "I am the first and the last; I am he who liveth, I am he who was slain; I am your advocate with the Father.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 110:5",
+							"text": "Behold, your sins are forgiven you; you are clean before me; therefore, lift up your heads and rejoice.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 110:6",
+							"text": "Let the hearts of your brethren rejoice, and let the hearts of all my people rejoice, who have, with their might, built this house to my name.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 110:7",
+							"text": "For behold, I have accepted this house, and my name shall be here; and I will manifest myself to my people in mercy in this house.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 110:8",
+							"text": "Yea, I will appear unto my servants, and speak unto them with mine own voice, if my people will keep my commandments, and do not pollute this holy house.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 110:9",
+							"text": "Yea the hearts of thousands and tens of thousands shall greatly rejoice in consequence of the blessings which shall be poured out, and the endowment with which my servants have been endowed in this house.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 110:10",
+							"text": "And the fame of this house shall spread to foreign lands; and this is the beginning of the blessing which shall be poured out upon the heads of my people. Even so. Amen.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 110:11",
+							"text": "After this vision closed, the heavens were again opened unto us; and Moses appeared before us, and committed unto us the keys of the gathering of Israel from the four parts of the earth, and the leading of the ten tribes from the land of the north.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 110:12",
+							"text": "After this, Elias appeared, and committed the dispensation of the gospel of Abraham, saying that in us and our seed all generations after us should be blessed.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 110:13",
+							"text": "After this vision had closed, another great and glorious vision burst upon us; for Elijah the prophet, who was taken to heaven without tasting death, stood before us, and said:",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 110:14",
+							"text": "Behold, the time has fully come, which was spoken of by the mouth of Malachi\u2014testifying that he [Elijah] should be sent, before the great and dreadful day of the Lord come\u2014",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 110:15",
+							"text": "To turn the hearts of the fathers to the children, and the children to the fathers, lest the whole earth be smitten with a curse\u2014",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 110:16",
+							"text": "Therefore, the keys of this dispensation are committed into your hands; and by this ye may know that the great and dreadful day of the Lord is near, even at the doors.",
+							"verse": 16
+						}
+					]
+				},
+				{
+					"chapter": 111,
+					"reference": "D&C 111",
+					"verses": [{
+							"reference": "D&C 111:1",
+							"text": "I, the Lord your God, am not displeased with your coming this journey, notwithstanding your follies.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 111:2",
+							"text": "I have much treasure in this city for you, for the benefit of Zion, and many people in this city, whom I will gather out in due time for the benefit of Zion, through your instrumentality.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 111:3",
+							"text": "Therefore, it is expedient that you should form acquaintance with men in this city, as you shall be led, and as it shall be given you.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 111:4",
+							"text": "And it shall come to pass in due time that I will give this city into your hands, that you shall have power over it, insomuch that they shall not discover your secret parts; and its wealth pertaining to gold and silver shall be yours.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 111:5",
+							"text": "Concern not yourselves about your debts, for I will give you power to pay them.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 111:6",
+							"text": "Concern not yourselves about Zion, for I will deal mercifully with her.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 111:7",
+							"text": "Tarry in this place, and in the regions round about;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 111:8",
+							"text": "And the place where it is my will that you should tarry, for the main, shall be signalized unto you by the peace and power of my Spirit, that shall flow unto you.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 111:9",
+							"text": "This place you may obtain by hire. And inquire diligently concerning the more ancient inhabitants and founders of this city;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 111:10",
+							"text": "For there are more treasures than one for you in this city.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 111:11",
+							"text": "Therefore, be ye as wise as serpents and yet without sin; and I will order all things for your good, as fast as ye are able to receive them. Amen.",
+							"verse": 11
+						}
+					]
+				},
+				{
+					"chapter": 112,
+					"reference": "D&C 112",
+					"verses": [{
+							"reference": "D&C 112:1",
+							"text": "Verily thus saith the Lord unto you my servant Thomas: I have heard thy prayers; and thine alms have come up as a memorial before me, in behalf of those, thy brethren, who were chosen to bear testimony of my name and to send it abroad among all nations, kindreds, tongues, and people, and ordained through the instrumentality of my servants.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 112:2",
+							"text": "Verily I say unto you, there have been some few things in thine heart and with thee with which I, the Lord, was not well pleased.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 112:3",
+							"text": "Nevertheless, inasmuch as thou hast abased thyself thou shalt be exalted; therefore, all thy sins are forgiven thee.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 112:4",
+							"text": "Let thy heart be of good cheer before my face; and thou shalt bear record of my name, not only unto the Gentiles, but also unto the Jews; and thou shalt send forth my word unto the ends of the earth.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 112:5",
+							"text": "Contend thou, therefore, morning by morning; and day after day let thy warning voice go forth; and when the night cometh let not the inhabitants of the earth slumber, because of thy speech.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 112:6",
+							"text": "Let thy habitation be known in Zion, and remove not thy house; for I, the Lord, have a great work for thee to do, in publishing my name among the children of men.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 112:7",
+							"text": "Therefore, gird up thy loins for the work. Let thy feet be shod also, for thou art chosen, and thy path lieth among the mountains, and among many nations.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 112:8",
+							"text": "And by thy word many high ones shall be brought low, and by thy word many low ones shall be exalted.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 112:9",
+							"text": "Thy voice shall be a rebuke unto the transgressor; and at thy rebuke let the tongue of the slanderer cease its perverseness.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 112:10",
+							"text": "Be thou humble; and the Lord thy God shall lead thee by the hand, and give thee answer to thy prayers.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 112:11",
+							"text": "I know thy heart, and have heard thy prayers concerning thy brethren. Be not partial towards them in love above many others, but let thy love be for them as for thyself; and let thy love abound unto all men, and unto all who love my name.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 112:12",
+							"text": "And pray for thy brethren of the Twelve. Admonish them sharply for my name's sake, and let them be admonished for all their sins, and be ye faithful before me unto my name.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 112:13",
+							"text": "And after their temptations, and much tribulation, behold, I, the Lord, will feel after them, and if they harden not their hearts, and stiffen not their necks against me, they shall be converted, and I will heal them.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 112:14",
+							"text": "Now, I say unto you, and what I say unto you, I say unto all the Twelve: Arise and gird up your loins, take up your cross, follow me, and feed my sheep.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 112:15",
+							"text": "Exalt not yourselves; rebel not against my servant Joseph; for verily I say unto you, I am with him, and my hand shall be over him; and the keys which I have given unto him, and also to youward, shall not be taken from him till I come.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 112:16",
+							"text": "Verily I say unto you, my servant Thomas, thou art the man whom I have chosen to hold the keys of my kingdom, as pertaining to the Twelve, abroad among all nations\u2014",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 112:17",
+							"text": "That thou mayest be my servant to unlock the door of the kingdom in all places where my servant Joseph, and my servant Sidney, and my servant Hyrum, cannot come;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 112:18",
+							"text": "For on them have I laid the burden of all the churches for a little season.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 112:19",
+							"text": "Wherefore, whithersoever they shall send you, go ye, and I will be with you; and in whatsoever place ye shall proclaim my name an effectual door shall be opened unto you, that they may receive my word.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 112:20",
+							"text": "Whosoever receiveth my word receiveth me, and whosoever receiveth me, receiveth those, the First Presidency, whom I have sent, whom I have made counselors for my name's sake unto you.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 112:21",
+							"text": "And again, I say unto you, that whosoever ye shall send in my name, by the voice of your brethren, the Twelve, duly recommended and authorized by you, shall have power to open the door of my kingdom unto any nation whithersoever ye shall send them\u2014",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 112:22",
+							"text": "Inasmuch as they shall humble themselves before me, and abide in my word, and hearken to the voice of my Spirit.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 112:23",
+							"text": "Verily, verily, I say unto you, darkness covereth the earth, and gross darkness the minds of the people, and all flesh has become corrupt before my face.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 112:24",
+							"text": "Behold, vengeance cometh speedily upon the inhabitants of the earth, a day of wrath, a day of burning, a day of desolation, of weeping, of mourning, and of lamentation; and as a whirlwind it shall come upon all the face of the earth, saith the Lord.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 112:25",
+							"text": "And upon my house shall it begin, and from my house shall it go forth, saith the Lord;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 112:26",
+							"text": "First among those among you, saith the Lord, who have professed to know my name and have not known me, and have blasphemed against me in the midst of my house, saith the Lord.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 112:27",
+							"text": "Therefore, see to it that ye trouble not yourselves concerning the affairs of my church in this place, saith the Lord.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 112:28",
+							"text": "But purify your hearts before me; and then go ye into all the world, and preach my gospel unto every creature who has not received it;",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 112:29",
+							"text": "And he that believeth and is baptized shall be saved, and he that believeth not, and is not baptized, shall be damned.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 112:30",
+							"text": "For unto you, the Twelve, and those, the First Presidency, who are appointed with you to be your counselors and your leaders, is the power of this priesthood given, for the last days and for the last time, in the which is the dispensation of the fulness of times,",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 112:31",
+							"text": "Which power you hold, in connection with all those who have received a dispensation at any time from the beginning of the creation;",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 112:32",
+							"text": "For verily I say unto you, the keys of the dispensation, which ye have received, have come down from the fathers, and last of all, being sent down from heaven unto you.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 112:33",
+							"text": "Verily I say unto you, behold how great is your calling. Cleanse your hearts and your garments, lest the blood of this generation be required at your hands.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 112:34",
+							"text": "Be faithful until I come, for I come quickly; and my reward is with me to recompense every man according as his work shall be. I am Alpha and Omega. Amen.",
+							"verse": 34
+						}
+					]
+				},
+				{
+					"chapter": 113,
+					"reference": "D&C 113",
+					"verses": [{
+							"reference": "D&C 113:1",
+							"text": "Who is the Stem of Jesse spoken of in the 1st, 2d, 3d, 4th, and 5th verses of the 11th chapter of Isaiah?",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 113:2",
+							"text": "Verily thus saith the Lord: It is Christ.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 113:3",
+							"text": "What is the rod spoken of in the first verse of the 11th chapter of Isaiah, that should come of the Stem of Jesse?",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 113:4",
+							"text": "Behold, thus saith the Lord: It is a servant in the hands of Christ, who is partly a descendant of Jesse as well as of Ephraim, or of the house of Joseph, on whom there is laid much power.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 113:5",
+							"text": "What is the root of Jesse spoken of in the 10th verse of the 11th chapter?",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 113:6",
+							"text": "Behold, thus saith the Lord, it is a descendant of Jesse, as well as of Joseph, unto whom rightly belongs the priesthood, and the keys of the kingdom, for an ensign, and for the gathering of my people in the last days.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 113:7",
+							"text": "Questions by Elias Higbee: What is meant by the command in Isaiah, 52d chapter, 1st verse, which saith: Put on thy strength, O Zion\u2014and what people had Isaiah reference to?",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 113:8",
+							"text": "He had reference to those whom God should call in the last days, who should hold the power of priesthood to bring again Zion, and the redemption of Israel; and to put on her strength is to put on the authority of the priesthood, which she, Zion, has a right to by lineage; also to return to that power which she had lost.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 113:9",
+							"text": "What are we to understand by Zion loosing herself from the bands of her neck; 2d verse?",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 113:10",
+							"text": "We are to understand that the scattered remnants are exhorted to return to the Lord from whence they have fallen; which if they do, the promise of the Lord is that he will speak to them, or give them revelation. See the 6th, 7th, and 8th verses. The bands of her neck are the curses of God upon her, or the remnants of Israel in their scattered condition among the Gentiles.",
+							"verse": 10
+						}
+					]
+				},
+				{
+					"chapter": 114,
+					"reference": "D&C 114",
+					"verses": [{
+							"reference": "D&C 114:1",
+							"text": "Verily thus saith the Lord: It is wisdom in my servant David W. Patten, that he settle up all his business as soon as he possibly can, and make a disposition of his merchandise, that he may perform a mission unto me next spring, in company with others, even twelve including himself, to testify of my name and bear glad tidings unto all the world.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 114:2",
+							"text": "For verily thus saith the Lord, that inasmuch as there are those among you who deny my name, others shall be planted in their stead and receive their bishopric. Amen.",
+							"verse": 2
+						}
+					]
+				},
+				{
+					"chapter": 115,
+					"reference": "D&C 115",
+					"verses": [{
+							"reference": "D&C 115:1",
+							"text": "Verily thus saith the Lord unto you, my servant Joseph Smith, Jun., and also my servant Sidney Rigdon, and also my servant Hyrum Smith, and your counselors who are and shall be appointed hereafter;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 115:2",
+							"text": "And also unto you, my servant Edward Partridge, and his counselors;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 115:3",
+							"text": "And also unto my faithful servants who are of the high council of my church in Zion, for thus it shall be called, and unto all the elders and people of my Church of Jesus Christ of Latter-day Saints, scattered abroad in all the world;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 115:4",
+							"text": "For thus shall my church be called in the last days, even The Church of Jesus Christ of Latter-day Saints.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 115:5",
+							"text": "Verily I say unto you all: Arise and shine forth, that thy light may be a standard for the nations;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 115:6",
+							"text": "And that the gathering together upon the land of Zion, and upon her stakes, may be for a defense, and for a refuge from the storm, and from wrath when it shall be poured out without mixture upon the whole earth.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 115:7",
+							"text": "Let the city, Far West, be a holy and consecrated land unto me; and it shall be called most holy, for the ground upon which thou standest is holy.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 115:8",
+							"text": "Therefore, I command you to build a house unto me, for the gathering together of my saints, that they may worship me.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 115:9",
+							"text": "And let there be a beginning of this work, and a foundation, and a preparatory work, this following summer;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 115:10",
+							"text": "And let the beginning be made on the fourth day of July next; and from that time forth let my people labor diligently to build a house unto my name;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 115:11",
+							"text": "And in one year from this day let them re-commence laying the foundation of my house.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 115:12",
+							"text": "Thus let them from that time forth labor diligently until it shall be finished, from the cornerstone thereof unto the top thereof, until there shall not anything remain that is not finished.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 115:13",
+							"text": "Verily I say unto you, let not my servant Joseph, neither my servant Sidney, neither my servant Hyrum, get in debt any more for the building of a house unto my name;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 115:14",
+							"text": "But let a house be built unto my name according to the pattern which I will show unto them.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 115:15",
+							"text": "And if my people build it not according to the pattern which I shall show unto their presidency, I will not accept it at their hands.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 115:16",
+							"text": "But if my people do build it according to the pattern which I shall show unto their presidency, even my servant Joseph and his counselors, then I will accept it at the hands of my people.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 115:17",
+							"text": "And again, verily I say unto you, it is my will that the city of Far West should be built up speedily by the gathering of my saints;",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 115:18",
+							"text": "And also that other places should be appointed for stakes in the regions round about, as they shall be manifested unto my servant Joseph, from time to time.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 115:19",
+							"text": "For behold, I will be with him, and I will sanctify him before the people; for unto him have I given the keys of this kingdom and ministry. Even so. Amen.",
+							"verse": 19
+						}
+					]
+				},
+				{
+					"chapter": 116,
+					"reference": "D&C 116",
+					"verses": [{
+						"reference": "D&C 116:1",
+						"text": "Spring Hill is named by the Lord Adam-ondi-Ahman, because, said he, it is the place where Adam shall come to visit his people, or the Ancient of Days shall sit, as spoken of by Daniel the prophet.",
+						"verse": 1
+					}]
+				},
+				{
+					"chapter": 117,
+					"reference": "D&C 117",
+					"verses": [{
+							"reference": "D&C 117:1",
+							"text": "Verily thus saith the Lord unto my servant William Marks, and also unto my servant Newel K. Whitney, let them settle up their business speedily and journey from the land of Kirtland, before I, the Lord, send again the snows upon the earth.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 117:2",
+							"text": "Let them awake, and arise, and come forth, and not tarry, for I, the Lord, command it.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 117:3",
+							"text": "Therefore, if they tarry it shall not be well with them.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 117:4",
+							"text": "Let them repent of all their sins, and of all their covetous desires, before me, saith the Lord; for what is property unto me? saith the Lord.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 117:5",
+							"text": "Let the properties of Kirtland be turned out for debts, saith the Lord. Let them go, saith the Lord, and whatsoever remaineth, let it remain in your hands, saith the Lord.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 117:6",
+							"text": "For have I not the fowls of heaven, and also the fish of the sea, and the beasts of the mountains? Have I not made the earth? Do I not hold the destinies of all the armies of the nations of the earth?",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 117:7",
+							"text": "Therefore, will I not make solitary places to bud and to blossom, and to bring forth in abundance? saith the Lord.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 117:8",
+							"text": "Is there not room enough on the mountains of Adam-ondi-Ahman, and on the plains of Olaha Shinehah, or the land where Adam dwelt, that you should covet that which is but the drop, and neglect the more weighty matters?",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 117:9",
+							"text": "Therefore, come up hither unto the land of my people, even Zion.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 117:10",
+							"text": "Let my servant William Marks be faithful over a few things, and he shall be a ruler over many. Let him preside in the midst of my people in the city of Far West, and let him be blessed with the blessings of my people.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 117:11",
+							"text": "Let my servant Newel K. Whitney be ashamed of the Nicolaitane band and of all their secret abominations, and of all his littleness of soul before me, saith the Lord, and come up to the land of Adam-ondi-Ahman, and be a bishop unto my people, saith the Lord, not in name but in deed, saith the Lord.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 117:12",
+							"text": "And again, I say unto you, I remember my servant Oliver Granger; behold, verily I say unto him that his name shall be had in sacred remembrance from generation to generation, forever and ever, saith the Lord.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 117:13",
+							"text": "Therefore, let him contend earnestly for the redemption of the First Presidency of my Church, saith the Lord; and when he falls he shall rise again, for his sacrifice shall be more sacred unto me than his increase, saith the Lord.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 117:14",
+							"text": "Therefore, let him come up hither speedily, unto the land of Zion; and in the due time he shall be made a merchant unto my name, saith the Lord, for the benefit of my people.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 117:15",
+							"text": "Therefore let no man despise my servant Oliver Granger, but let the blessings of my people be on him forever and ever.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 117:16",
+							"text": "And again, verily I say unto you, let all my servants in the land of Kirtland remember the Lord their God, and mine house also, to keep and preserve it holy, and to overthrow the moneychangers in mine own due time, saith the Lord. Even so. Amen.",
+							"verse": 16
+						}
+					]
+				},
+				{
+					"chapter": 118,
+					"reference": "D&C 118",
+					"verses": [{
+							"reference": "D&C 118:1",
+							"text": "Verily, thus saith the Lord: Let a conference be held immediately; let the Twelve be organized; and let men be appointed to supply the place of those who are fallen.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 118:2",
+							"text": "Let my servant Thomas remain for a season in the land of Zion, to publish my word.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 118:3",
+							"text": "Let the residue continue to preach from that hour, and if they will do this in all lowliness of heart, in meekness and humility, and long-suffering, I, the Lord, give unto them a promise that I will provide for their families; and an effectual door shall be opened for them, from henceforth.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 118:4",
+							"text": "And next spring let them depart to go over the great waters, and there promulgate my gospel, the fulness thereof, and bear record of my name.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 118:5",
+							"text": "Let them take leave of my saints in the city of Far West, on the twenty-sixth day of April next, on the building-spot of my house, saith the Lord.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 118:6",
+							"text": "Let my servant John Taylor, and also my servant John E. Page, and also my servant Wilford Woodruff, and also my servant Willard Richards, be appointed to fill the places of those who have fallen, and be officially notified of their appointment.",
+							"verse": 6
+						}
+					]
+				},
+				{
+					"chapter": 119,
+					"reference": "D&C 119",
+					"verses": [{
+							"reference": "D&C 119:1",
+							"text": "Verily, thus saith the Lord, I require all their surplus property to be put into the hands of the bishop of my church in Zion,",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 119:2",
+							"text": "For the building of mine house, and for the laying of the foundation of Zion and for the priesthood, and for the debts of the Presidency of my Church.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 119:3",
+							"text": "And this shall be the beginning of the tithing of my people.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 119:4",
+							"text": "And after that, those who have thus been tithed shall pay one-tenth of all their interest annually; and this shall be a standing law unto them forever, for my holy priesthood, saith the Lord.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 119:5",
+							"text": "Verily I say unto you, it shall come to pass that all those who gather unto the land of Zion shall be tithed of their surplus properties, and shall observe this law, or they shall not be found worthy to abide among you.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 119:6",
+							"text": "And I say unto you, if my people observe not this law, to keep it holy, and by this law sanctify the land of Zion unto me, that my statutes and my judgments may be kept thereon, that it may be most holy, behold, verily I say unto you, it shall not be a land of Zion unto you.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 119:7",
+							"text": "And this shall be an ensample unto all the stakes of Zion. Even so. Amen.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 120,
+					"reference": "D&C 120",
+					"verses": [{
+						"reference": "D&C 120:1",
+						"text": "Verily, thus saith the Lord, the time is now come, that it shall be disposed of by a council, composed of the First Presidency of my Church, and of the bishop and his council, and by my high council; and by mine own voice unto them, saith the Lord. Even so. Amen.",
+						"verse": 1
+					}]
+				},
+				{
+					"chapter": 121,
+					"reference": "D&C 121",
+					"verses": [{
+							"reference": "D&C 121:1",
+							"text": "O God, where art thou? And where is the pavilion that covereth thy hiding place?",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 121:2",
+							"text": "How long shall thy hand be stayed, and thine eye, yea thy pure eye, behold from the eternal heavens the wrongs of thy people and of thy servants, and thine ear be penetrated with their cries?",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 121:3",
+							"text": "Yea, O Lord, how long shall they suffer these wrongs and unlawful oppressions, before thine heart shall be softened toward them, and thy bowels be moved with compassion toward them?",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 121:4",
+							"text": "O Lord God Almighty, maker of heaven, earth, and seas, and of all things that in them are, and who controllest and subjectest the devil, and the dark and benighted dominion of Sheol\u2014stretch forth thy hand; let thine eye pierce; let thy pavilion be taken up; let thy hiding place no longer be covered; let thine ear be inclined; let thine heart be softened, and thy bowels moved with compassion toward us.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 121:5",
+							"text": "Let thine anger be kindled against our enemies; and, in the fury of thine heart, with thy sword avenge us of our wrongs.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 121:6",
+							"text": "Remember thy suffering saints, O our God; and thy servants will rejoice in thy name forever.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 121:7",
+							"text": "My son, peace be unto thy soul; thine adversity and thine afflictions shall be but a small moment;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 121:8",
+							"text": "And then, if thou endure it well, God shall exalt thee on high; thou shalt triumph over all thy foes.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 121:9",
+							"text": "Thy friends do stand by thee, and they shall hail thee again with warm hearts and friendly hands.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 121:10",
+							"text": "Thou art not yet as Job; thy friends do not contend against thee, neither charge thee with transgression, as they did Job.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 121:11",
+							"text": "And they who do charge thee with transgression, their hope shall be blasted, and their prospects shall melt away as the hoar frost melteth before the burning rays of the rising sun;",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 121:12",
+							"text": "And also that God hath set his hand and seal to change the times and seasons, and to blind their minds, that they may not understand his marvelous workings; that he may prove them also and take them in their own craftiness;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 121:13",
+							"text": "Also because their hearts are corrupted, and the things which they are willing to bring upon others, and love to have others suffer, may come upon themselves to the very uttermost;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 121:14",
+							"text": "That they may be disappointed also, and their hopes may be cut off;",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 121:15",
+							"text": "And not many years hence, that they and their posterity shall be swept from under heaven, saith God, that not one of them is left to stand by the wall.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 121:16",
+							"text": "Cursed are all those that shall lift up the heel against mine anointed, saith the Lord, and cry they have sinned when they have not sinned before me, saith the Lord, but have done that which was meet in mine eyes, and which I commanded them.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 121:17",
+							"text": "But those who cry transgression do it because they are the servants of sin, and are the children of disobedience themselves.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 121:18",
+							"text": "And those who swear falsely against my servants, that they might bring them into bondage and death\u2014",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 121:19",
+							"text": "Wo unto them; because they have offended my little ones they shall be severed from the ordinances of mine house.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 121:20",
+							"text": "Their basket shall not be full, their houses and their barns shall perish, and they themselves shall be despised by those that flattered them.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 121:21",
+							"text": "They shall not have right to the priesthood, nor their posterity after them from generation to generation.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 121:22",
+							"text": "It had been better for them that a millstone had been hanged about their necks, and they drowned in the depth of the sea.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 121:23",
+							"text": "Wo unto all those that discomfort my people, and drive, and murder, and testify against them, saith the Lord of Hosts; a generation of vipers shall not escape the damnation of hell.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 121:24",
+							"text": "Behold, mine eyes see and know all their works, and I have in reserve a swift judgment in the season thereof, for them all;",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 121:25",
+							"text": "For there is a time appointed for every man, according as his works shall be.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 121:26",
+							"text": "God shall give unto you knowledge by his Holy Spirit, yea, by the unspeakable gift of the Holy Ghost, that has not been revealed since the world was until now;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 121:27",
+							"text": "Which our forefathers have awaited with anxious expectation to be revealed in the last times, which their minds were pointed to by the angels, as held in reserve for the fulness of their glory;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 121:28",
+							"text": "A time to come in the which nothing shall be withheld, whether there be one God or many gods, they shall be manifest.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 121:29",
+							"text": "All thrones and dominions, principalities and powers, shall be revealed and set forth upon all who have endured valiantly for the gospel of Jesus Christ.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 121:30",
+							"text": "And also, if there be bounds set to the heavens or to the seas, or to the dry land, or to the sun, moon, or stars\u2014",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 121:31",
+							"text": "All the times of their revolutions, all the appointed days, months, and years, and all the days of their days, months, and years, and all their glories, laws, and set times, shall be revealed in the days of the dispensation of the fulness of times\u2014",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 121:32",
+							"text": "According to that which was ordained in the midst of the Council of the Eternal God of all other gods before this world was, that should be reserved unto the finishing and the end thereof, when every man shall enter into his eternal presence and into his immortal rest.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 121:33",
+							"text": "How long can rolling waters remain impure? What power shall stay the heavens? As well might man stretch forth his puny arm to stop the Missouri river in its decreed course, or to turn it up stream, as to hinder the Almighty from pouring down knowledge from heaven upon the heads of the Latter-day Saints.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 121:34",
+							"text": "Behold, there are many called, but few are chosen. And why are they not chosen?",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 121:35",
+							"text": "Because their hearts are set so much upon the things of this world, and aspire to the honors of men, that they do not learn this one lesson\u2014",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 121:36",
+							"text": "That the rights of the priesthood are inseparably connected with the powers of heaven, and that the powers of heaven cannot be controlled nor handled only upon the principles of righteousness.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 121:37",
+							"text": "That they may be conferred upon us, it is true; but when we undertake to cover our sins, or to gratify our pride, our vain ambition, or to exercise control or dominion or compulsion upon the souls of the children of men, in any degree of unrighteousness, behold, the heavens withdraw themselves; the Spirit of the Lord is grieved; and when it is withdrawn, Amen to the priesthood or the authority of that man.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 121:38",
+							"text": "Behold, ere he is aware, he is left unto himself, to kick against the pricks, to persecute the saints, and to fight against God.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 121:39",
+							"text": "We have learned by sad experience that it is the nature and disposition of almost all men, as soon as they get a little authority, as they suppose, they will immediately begin to exercise unrighteous dominion.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 121:40",
+							"text": "Hence many are called, but few are chosen.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 121:41",
+							"text": "No power or influence can or ought to be maintained by virtue of the priesthood, only by persuasion, by long-suffering, by gentleness and meekness, and by love unfeigned;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 121:42",
+							"text": "By kindness, and pure knowledge, which shall greatly enlarge the soul without hypocrisy, and without guile\u2014",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 121:43",
+							"text": "Reproving betimes with sharpness, when moved upon by the Holy Ghost; and then showing forth afterwards an increase of love toward him whom thou hast reproved, lest he esteem thee to be his enemy;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 121:44",
+							"text": "That he may know that thy faithfulness is stronger than the cords of death.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 121:45",
+							"text": "Let thy bowels also be full of charity towards all men, and to the household of faith, and let virtue garnish thy thoughts unceasingly; then shall thy confidence wax strong in the presence of God; and the doctrine of the priesthood shall distil upon thy soul as the dews from heaven.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 121:46",
+							"text": "The Holy Ghost shall be thy constant companion, and thy scepter an unchanging scepter of righteousness and truth; and thy dominion shall be an everlasting dominion, and without compulsory means it shall flow unto thee forever and ever.",
+							"verse": 46
+						}
+					]
+				},
+				{
+					"chapter": 122,
+					"reference": "D&C 122",
+					"verses": [{
+							"reference": "D&C 122:1",
+							"text": "The ends of the earth shall inquire after thy name, and fools shall have thee in derision, and hell shall rage against thee;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 122:2",
+							"text": "While the pure in heart, and the wise, and the noble, and the virtuous, shall seek counsel, and authority, and blessings constantly from under thy hand.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 122:3",
+							"text": "And thy people shall never be turned against thee by the testimony of traitors.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 122:4",
+							"text": "And although their influence shall cast thee into trouble, and into bars and walls, thou shalt be had in honor; and but for a small moment and thy voice shall be more terrible in the midst of thine enemies than the fierce lion, because of thy righteousness; and thy God shall stand by thee forever and ever.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 122:5",
+							"text": "If thou art called to pass through tribulation; if thou art in perils among false brethren; if thou art in perils among robbers; if thou art in perils by land or by sea;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 122:6",
+							"text": "If thou art accused with all manner of false accusations; if thine enemies fall upon thee; if they tear thee from the society of thy father and mother and brethren and sisters; and if with a drawn sword thine enemies tear thee from the bosom of thy wife, and of thine offspring, and thine elder son, although but six years of age, shall cling to thy garments, and shall say, My father, my father, why can't you stay with us? O, my father, what are the men going to do with you? and if then he shall be thrust from thee by the sword, and thou be dragged to prison, and thine enemies prowl around thee like wolves for the blood of the lamb;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 122:7",
+							"text": "And if thou shouldst be cast into the pit, or into the hands of murderers, and the sentence of death passed upon thee; if thou be cast into the deep; if the billowing surge conspire against thee; if fierce winds become thine enemy; if the heavens gather blackness, and all the elements combine to hedge up the way; and above all, if the very jaws of hell shall gape open the mouth wide after thee, know thou, my son, that all these things shall give thee experience, and shall be for thy good.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 122:8",
+							"text": "The Son of Man hath descended below them all. Art thou greater than he?",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 122:9",
+							"text": "Therefore, hold on thy way, and the priesthood shall remain with thee; for their bounds are set, they cannot pass. Thy days are known, and thy years shall not be numbered less; therefore, fear not what man can do, for God shall be with you forever and ever.",
+							"verse": 9
+						}
+					]
+				},
+				{
+					"chapter": 123,
+					"reference": "D&C 123",
+					"verses": [{
+							"reference": "D&C 123:1",
+							"text": "And again, we would suggest for your consideration the propriety of all the saints gathering up a knowledge of all the facts, and sufferings and abuses put upon them by the people of this State;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 123:2",
+							"text": "And also of all the property and amount of damages which they have sustained, both of character and personal injuries, as well as real property;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 123:3",
+							"text": "And also the names of all persons that have had a hand in their oppressions, as far as they can get hold of them and find them out.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 123:4",
+							"text": "And perhaps a committee can be appointed to find out these things, and to take statements and affidavits; and also to gather up the libelous publications that are afloat;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 123:5",
+							"text": "And all that are in the magazines, and in the encyclopedias, and all the libelous histories that are published, and are writing, and by whom, and present the whole concatenation of diabolical rascality and nefarious and murderous impositions that have been practiced upon this people\u2014",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 123:6",
+							"text": "That we may not only publish to all the world, but present them to the heads of government in all their dark and hellish hue, as the last effort which is enjoined on us by our Heavenly Father, before we can fully and completely claim that promise which shall call him forth from his hiding place; and also that the whole nation may be left without excuse before he can send forth the power of his mighty arm.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 123:7",
+							"text": "It is an imperative duty that we owe to God, to angels, with whom we shall be brought to stand, and also to ourselves, to our wives and children, who have been made to bow down with grief, sorrow, and care, under the most damning hand of murder, tyranny, and oppression, supported and urged on and upheld by the influence of that spirit which hath so strongly riveted the creeds of the fathers, who have inherited lies, upon the hearts of the children, and filled the world with confusion, and has been growing stronger and stronger, and is now the very mainspring of all corruption, and the whole earth groans under the weight of its iniquity.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 123:8",
+							"text": "It is an iron yoke, it is a strong band; they are the very handcuffs, and chains, and shackles, and fetters of hell.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 123:9",
+							"text": "Therefore it is an imperative duty that we owe, not only to our own wives and children, but to the widows and fatherless, whose husbands and fathers have been murdered under its iron hand;",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 123:10",
+							"text": "Which dark and blackening deeds are enough to make hell itself shudder, and to stand aghast and pale, and the hands of the very devil to tremble and palsy.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 123:11",
+							"text": "And also it is an imperative duty that we owe to all the rising generation, and to all the pure in heart\u2014",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 123:12",
+							"text": "For there are many yet on the earth among all sects, parties, and denominations, who are blinded by the subtle craftiness of men, whereby they lie in wait to deceive, and who are only kept from the truth because they know not where to find it\u2014",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 123:13",
+							"text": "Therefore, that we should waste and wear out our lives in bringing to light all the hidden things of darkness, wherein we know them; and they are truly manifest from heaven\u2014",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 123:14",
+							"text": "These should then be attended to with great earnestness.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 123:15",
+							"text": "Let no man count them as small things; for there is much which lieth in futurity, pertaining to the saints, which depends upon these things.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 123:16",
+							"text": "You know, brethren, that a very large ship is benefited very much by a very small helm in the time of a storm, by being kept workways with the wind and the waves.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 123:17",
+							"text": "Therefore, dearly beloved brethren, let us cheerfully do all things that lie in our power; and then may we stand still, with the utmost assurance, to see the salvation of God, and for his arm to be revealed.",
+							"verse": 17
+						}
+					]
+				},
+				{
+					"chapter": 124,
+					"reference": "D&C 124",
+					"verses": [{
+							"reference": "D&C 124:1",
+							"text": "Verily, thus saith the Lord unto you, my servant Joseph Smith, I am well pleased with your offering and acknowledgments, which you have made; for unto this end have I raised you up, that I might show forth my wisdom through the weak things of the earth.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 124:2",
+							"text": "Your prayers are acceptable before me; and in answer to them I say unto you, that you are now called immediately to make a solemn proclamation of my gospel, and of this stake which I have planted to be a cornerstone of Zion, which shall be polished with the refinement which is after the similitude of a palace.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 124:3",
+							"text": "This proclamation shall be made to all the kings of the world, to the four corners thereof, to the honorable president-elect, and the high-minded governors of the nation in which you live, and to all the nations of the earth scattered abroad.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 124:4",
+							"text": "Let it be written in the spirit of meekness and by the power of the Holy Ghost, which shall be in you at the time of the writing of the same;",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 124:5",
+							"text": "For it shall be given you by the Holy Ghost to know my will concerning those kings and authorities, even what shall befall them in a time to come.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 124:6",
+							"text": "For, behold, I am about to call upon them to give heed to the light and glory of Zion, for the set time has come to favor her.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 124:7",
+							"text": "Call ye, therefore, upon them with loud proclamation, and with your testimony, fearing them not, for they are as grass, and all their glory as the flower thereof which soon falleth, that they may be left also without excuse\u2014",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 124:8",
+							"text": "And that I may visit them in the day of visitation, when I shall unveil the face of my covering, to appoint the portion of the oppressor among hypocrites, where there is gnashing of teeth, if they reject my servants and my testimony which I have revealed unto them.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 124:9",
+							"text": "And again, I will visit and soften their hearts, many of them for your good, that ye may find grace in their eyes, that they may come to the light of truth, and the Gentiles to the exaltation or lifting up of Zion.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 124:10",
+							"text": "For the day of my visitation cometh speedily, in an hour when ye think not of; and where shall be the safety of my people, and refuge for those who shall be left of them?",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 124:11",
+							"text": "Awake, O kings of the earth! Come ye, O, come ye, with your gold and your silver, to the help of my people, to the house of the daughters of Zion.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 124:12",
+							"text": "And again, verily I say unto you, let my servant Robert B. Thompson help you to write this proclamation, for I am well pleased with him, and that he should be with you;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 124:13",
+							"text": "Let him, therefore, hearken to your counsel, and I will bless him with a multiplicity of blessings; let him be faithful and true in all things from henceforth, and he shall be great in mine eyes;",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 124:14",
+							"text": "But let him remember that his stewardship will I require at his hands.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 124:15",
+							"text": "And again, verily I say unto you, blessed is my servant Hyrum Smith; for I, the Lord, love him because of the integrity of his heart, and because he loveth that which is right before me, saith the Lord.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 124:16",
+							"text": "Again, let my servant John C. Bennett help you in your labor in sending my word to the kings and people of the earth, and stand by you, even you my servant Joseph Smith, in the hour of affliction; and his reward shall not fail if he receive counsel.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 124:17",
+							"text": "And for his love he shall be great, for he shall be mine if he do this, saith the Lord. I have seen the work which he hath done, which I accept if he continue, and will crown him with blessings and great glory.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 124:18",
+							"text": "And again, I say unto you that it is my will that my servant Lyman Wight should continue in preaching for Zion, in the spirit of meekness, confessing me before the world; and I will bear him up as on eagles' wings; and he shall beget glory and honor to himself and unto my name.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 124:19",
+							"text": "That when he shall finish his work I may receive him unto myself, even as I did my servant David Patten, who is with me at this time, and also my servant Edward Partridge, and also my aged servant Joseph Smith, Sen., who sitteth with Abraham at his right hand, and blessed and holy is he, for he is mine.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 124:20",
+							"text": "And again, verily I say unto you, my servant George Miller is without guile; he may be trusted because of the integrity of his heart; and for the love which he has to my testimony I, the Lord, love him.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 124:21",
+							"text": "I therefore say unto you, I seal upon his head the office of a bishopric, like unto my servant Edward Partridge, that he may receive the consecrations of mine house, that he may administer blessings upon the heads of the poor of my people, saith the Lord. Let no man despise my servant George, for he shall honor me.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 124:22",
+							"text": "Let my servant George, and my servant Lyman, and my servant John Snider, and others, build a house unto my name, such a one as my servant Joseph shall show unto them, upon the place which he shall show unto them also.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 124:23",
+							"text": "And it shall be for a house for boarding, a house that strangers may come from afar to lodge therein; therefore let it be a good house, worthy of all acceptation, that the weary traveler may find health and safety while he shall contemplate the word of the Lord; and the cornerstone I have appointed for Zion.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 124:24",
+							"text": "This house shall be a healthful habitation if it be built unto my name, and if the governor which shall be appointed unto it shall not suffer any pollution to come upon it. It shall be holy, or the Lord your God will not dwell therein.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 124:25",
+							"text": "And again, verily I say unto you, let all my saints come from afar.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 124:26",
+							"text": "And send ye swift messengers, yea, chosen messengers, and say unto them: Come ye, with all your gold, and your silver, and your precious stones, and with all your antiquities; and with all who have knowledge of antiquities, that will come, may come, and bring the box tree, and the fir tree, and the pine tree, together with all the precious trees of the earth;",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 124:27",
+							"text": "And with iron, with copper, and with brass, and with zinc, and with all your precious things of the earth; and build a house to my name, for the Most High to dwell therein.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 124:28",
+							"text": "For there is not a place found on earth that he may come to and restore again that which was lost unto you, or which he hath taken away, even the fulness of the priesthood.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 124:29",
+							"text": "For a baptismal font there is not upon the earth, that they, my saints, may be baptized for those who are dead\u2014",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 124:30",
+							"text": "For this ordinance belongeth to my house, and cannot be acceptable to me, only in the days of your poverty, wherein ye are not able to build a house unto me.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 124:31",
+							"text": "But I command you, all ye my saints, to build a house unto me; and I grant unto you a sufficient time to build a house unto me; and during this time your baptisms shall be acceptable unto me.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 124:32",
+							"text": "But behold, at the end of this appointment your baptisms for your dead shall not be acceptable unto me; and if you do not these things at the end of the appointment ye shall be rejected as a church, with your dead, saith the Lord your God.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 124:33",
+							"text": "For verily I say unto you, that after you have had sufficient time to build a house to me, wherein the ordinance of baptizing for the dead belongeth, and for which the same was instituted from before the foundation of the world, your baptisms for your dead cannot be acceptable unto me;",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 124:34",
+							"text": "For therein are the keys of the holy priesthood ordained, that you may receive honor and glory.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 124:35",
+							"text": "And after this time, your baptisms for the dead, by those who are scattered abroad, are not acceptable unto me, saith the Lord.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 124:36",
+							"text": "For it is ordained that in Zion, and in her stakes, and in Jerusalem, those places which I have appointed for refuge, shall be the places for your baptisms for your dead.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 124:37",
+							"text": "And again, verily I say unto you, how shall your washings be acceptable unto me, except ye perform them in a house which you have built to my name?",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 124:38",
+							"text": "For, for this cause I commanded Moses that he should build a tabernacle, that they should bear it with them in the wilderness, and to build a house in the land of promise, that those ordinances might be revealed which had been hid from before the world was.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 124:39",
+							"text": "Therefore, verily I say unto you, that your anointings, and your washings, and your baptisms for the dead, and your solemn assemblies, and your memorials for your sacrifices by the sons of Levi, and for your oracles in your most holy places wherein you receive conversations, and your statutes and judgments, for the beginning of the revelations and foundation of Zion, and for the glory, honor, and endowment of all her municipals, are ordained by the ordinance of my holy house, which my people are always commanded to build unto my holy name.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 124:40",
+							"text": "And verily I say unto you, let this house be built unto my name, that I may reveal mine ordinances therein unto my people;",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 124:41",
+							"text": "For I deign to reveal unto my church things which have been kept hid from before the foundation of the world, things that pertain to the dispensation of the fulness of times.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 124:42",
+							"text": "And I will show unto my servant Joseph all things pertaining to this house, and the priesthood thereof, and the place whereon it shall be built.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 124:43",
+							"text": "And ye shall build it on the place where you have contemplated building it, for that is the spot which I have chosen for you to build it.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 124:44",
+							"text": "If ye labor with all your might, I will consecrate that spot that it shall be made holy.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 124:45",
+							"text": "And if my people will hearken unto my voice, and unto the voice of my servants whom I have appointed to lead my people, behold, verily I say unto you, they shall not be moved out of their place.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 124:46",
+							"text": "But if they will not hearken to my voice, nor unto the voice of these men whom I have appointed, they shall not be blest, because they pollute mine holy grounds, and mine holy ordinances, and charters, and my holy words which I give unto them.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 124:47",
+							"text": "And it shall come to pass that if you build a house unto my name, and do not do the things that I say, I will not perform the oath which I make unto you, neither fulfil the promises which ye expect at my hands, saith the Lord.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 124:48",
+							"text": "For instead of blessings, ye, by your own works, bring cursings, wrath, indignation, and judgments upon your own heads, by your follies, and by all your abominations, which you practice before me, saith the Lord.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 124:49",
+							"text": "Verily, verily, I say unto you, that when I give a commandment to any of the sons of men to do a work unto my name, and those sons of men go with all their might and with all they have to perform that work, and cease not their diligence, and their enemies come upon them and hinder them from performing that work, behold, it behooveth me to require that work no more at the hands of those sons of men, but to accept of their offerings.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 124:50",
+							"text": "And the iniquity and transgression of my holy laws and commandments I will visit upon the heads of those who hindered my work, unto the third and fourth generation, so long as they repent not, and hate me, saith the Lord God.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 124:51",
+							"text": "Therefore, for this cause have I accepted the offerings of those whom I commanded to build up a city and a house unto my name, in Jackson county, Missouri, and were hindered by their enemies, saith the Lord your God.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 124:52",
+							"text": "And I will answer judgment, wrath, and indignation, wailing, and anguish, and gnashing of teeth upon their heads, unto the third and fourth generation, so long as they repent not, and hate me, saith the Lord your God.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 124:53",
+							"text": "And this I make an example unto you, for your consolation concerning all those who have been commanded to do a work and have been hindered by the hands of their enemies, and by oppression, saith the Lord your God.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 124:54",
+							"text": "For I am the Lord your God, and will save all those of your brethren who have been pure in heart, and have been slain in the land of Missouri, saith the Lord.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 124:55",
+							"text": "And again, verily I say unto you, I command you again to build a house to my name, even in this place, that you may prove yourselves unto me that ye are faithful in all things whatsoever I command you, that I may bless you, and crown you with honor, immortality, and eternal life.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 124:56",
+							"text": "And now I say unto you, as pertaining to my boarding house which I have commanded you to build for the boarding of strangers, let it be built unto my name, and let my name be named upon it, and let my servant Joseph and his house have place therein, from generation to generation.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 124:57",
+							"text": "For this anointing have I put upon his head, that his blessing shall also be put upon the head of his posterity after him.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 124:58",
+							"text": "And as I said unto Abraham concerning the kindreds of the earth, even so I say unto my servant Joseph: In thee and in thy seed shall the kindred of the earth be blessed.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 124:59",
+							"text": "Therefore, let my servant Joseph and his seed after him have place in that house, from generation to generation, forever and ever, saith the Lord.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 124:60",
+							"text": "And let the name of that house be called Nauvoo House; and let it be a delightful habitation for man, and a resting-place for the weary traveler, that he may contemplate the glory of Zion, and the glory of this, the cornerstone thereof;",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 124:61",
+							"text": "That he may receive also the counsel from those whom I have set to be as plants of renown, and as watchmen upon her walls.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 124:62",
+							"text": "Behold, verily I say unto you, let my servant George Miller, and my servant Lyman Wight, and my servant John Snider, and my servant Peter Haws, organize themselves, and appoint one of them to be a president over their quorum for the purpose of building that house.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 124:63",
+							"text": "And they shall form a constitution, whereby they may receive stock for the building of that house.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 124:64",
+							"text": "And they shall not receive less than fifty dollars for a share of stock in that house, and they shall be permitted to receive fifteen thousand dollars from any one man for stock in that house.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 124:65",
+							"text": "But they shall not be permitted to receive over fifteen thousand dollars stock from any one man.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 124:66",
+							"text": "And they shall not be permitted to receive under fifty dollars for a share of stock from any one man in that house.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 124:67",
+							"text": "And they shall not be permitted to receive any man, as a stockholder in this house, except the same shall pay his stock into their hands at the time he receives stock;",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 124:68",
+							"text": "And in proportion to the amount of stock he pays into their hands he shall receive stock in that house; but if he pays nothing into their hands he shall not receive any stock in that house.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 124:69",
+							"text": "And if any pay stock into their hands it shall be for stock in that house, for himself, and for his generation after him, from generation to generation, so long as he and his heirs shall hold that stock, and do not sell or convey the stock away out of their hands by their own free will and act, if you will do my will, saith the Lord your God.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 124:70",
+							"text": "And again, verily I say unto you, if my servant George Miller, and my servant Lyman Wight, and my servant John Snider, and my servant Peter Haws, receive any stock into their hands, in moneys, or in properties wherein they receive the real value of moneys, they shall not appropriate any portion of that stock to any other purpose, only in that house.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 124:71",
+							"text": "And if they do appropriate any portion of that stock anywhere else, only in that house, without the consent of the stockholder, and do not repay four-fold for the stock which they appropriate anywhere else, only in that house, they shall be accursed, and shall be moved out of their place, saith the Lord God; for I, the Lord, am God, and cannot be mocked in any of these things.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 124:72",
+							"text": "Verily I say unto you, let my servant Joseph pay stock into their hands for the building of that house, as seemeth him good; but my servant Joseph cannot pay over fifteen thousand dollars stock in that house, nor under fifty dollars; neither can any other man, saith the Lord.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 124:73",
+							"text": "And there are others also who wish to know my will concerning them, for they have asked it at my hands.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 124:74",
+							"text": "Therefore, I say unto you concerning my servant Vinson Knight, if he will do my will let him put stock into that house for himself, and for his generation after him, from generation to generation.",
+							"verse": 74
+						},
+						{
+							"reference": "D&C 124:75",
+							"text": "And let him lift up his voice long and loud, in the midst of the people, to plead the cause of the poor and the needy; and let him not fail, neither let his heart faint; and I will accept of his offerings, for they shall not be unto me as the offerings of Cain, for he shall be mine, saith the Lord.",
+							"verse": 75
+						},
+						{
+							"reference": "D&C 124:76",
+							"text": "Let his family rejoice and turn away their hearts from affliction; for I have chosen him and anointed him, and he shall be honored in the midst of his house, for I will forgive all his sins, saith the Lord. Amen.",
+							"verse": 76
+						},
+						{
+							"reference": "D&C 124:77",
+							"text": "Verily I say unto you, let my servant Hyrum put stock into that house as seemeth him good, for himself and his generation after him, from generation to generation.",
+							"verse": 77
+						},
+						{
+							"reference": "D&C 124:78",
+							"text": "Let my servant Isaac Galland put stock into that house; for I, the Lord, love him for the work he hath done, and will forgive all his sins; therefore, let him be remembered for an interest in that house from generation to generation.",
+							"verse": 78
+						},
+						{
+							"reference": "D&C 124:79",
+							"text": "Let my servant Isaac Galland be appointed among you, and be ordained by my servant William Marks, and be blessed of him, to go with my servant Hyrum to accomplish the work that my servant Joseph shall point out to them, and they shall be greatly blessed.",
+							"verse": 79
+						},
+						{
+							"reference": "D&C 124:80",
+							"text": "Let my servant William Marks pay stock into that house, as seemeth him good, for himself and his generation, from generation to generation.",
+							"verse": 80
+						},
+						{
+							"reference": "D&C 124:81",
+							"text": "Let my servant Henry G. Sherwood pay stock into that house, as seemeth him good, for himself and his seed after him, from generation to generation.",
+							"verse": 81
+						},
+						{
+							"reference": "D&C 124:82",
+							"text": "Let my servant William Law pay stock into that house, for himself and his seed after him, from generation to generation.",
+							"verse": 82
+						},
+						{
+							"reference": "D&C 124:83",
+							"text": "If he will do my will let him not take his family unto the eastern lands, even unto Kirtland; nevertheless, I, the Lord, will build up Kirtland, but I, the Lord, have a scourge prepared for the inhabitants thereof.",
+							"verse": 83
+						},
+						{
+							"reference": "D&C 124:84",
+							"text": "And with my servant Almon Babbitt, there are many things with which I am not pleased; behold, he aspireth to establish his counsel instead of the counsel which I have ordained, even that of the Presidency of my Church; and he setteth up a golden calf for the worship of my people.",
+							"verse": 84
+						},
+						{
+							"reference": "D&C 124:85",
+							"text": "Let no man go from this place who has come here essaying to keep my commandments.",
+							"verse": 85
+						},
+						{
+							"reference": "D&C 124:86",
+							"text": "If they live here let them live unto me; and if they die let them die unto me; for they shall rest from all their labors here, and shall continue their works.",
+							"verse": 86
+						},
+						{
+							"reference": "D&C 124:87",
+							"text": "Therefore, let my servant William put his trust in me, and cease to fear concerning his family, because of the sickness of the land. If ye love me, keep my commandments; and the sickness of the land shall redound to your glory.",
+							"verse": 87
+						},
+						{
+							"reference": "D&C 124:88",
+							"text": "Let my servant William go and proclaim my everlasting gospel with a loud voice, and with great joy, as he shall be moved upon by my Spirit, unto the inhabitants of Warsaw, and also unto the inhabitants of Carthage, and also unto the inhabitants of Burlington, and also unto the inhabitants of Madison, and await patiently and diligently for further instructions at my general conference, saith the Lord.",
+							"verse": 88
+						},
+						{
+							"reference": "D&C 124:89",
+							"text": "If he will do my will let him from henceforth hearken to the counsel of my servant Joseph, and with his interest support the cause of the poor, and publish the new translation of my holy word unto the inhabitants of the earth.",
+							"verse": 89
+						},
+						{
+							"reference": "D&C 124:90",
+							"text": "And if he will do this I will bless him with a multiplicity of blessings, that he shall not be forsaken, nor his seed be found begging bread.",
+							"verse": 90
+						},
+						{
+							"reference": "D&C 124:91",
+							"text": "And again, verily I say unto you, let my servant William be appointed, ordained, and anointed, as counselor unto my servant Joseph, in the room of my servant Hyrum, that my servant Hyrum may take the office of Priesthood and Patriarch, which was appointed unto him by his father, by blessing and also by right;",
+							"verse": 91
+						},
+						{
+							"reference": "D&C 124:92",
+							"text": "That from henceforth he shall hold the keys of the patriarchal blessings upon the heads of all my people,",
+							"verse": 92
+						},
+						{
+							"reference": "D&C 124:93",
+							"text": "That whoever he blesses shall be blessed, and whoever he curses shall be cursed; that whatsoever he shall bind on earth shall be bound in heaven; and whatsoever he shall loose on earth shall be loosed in heaven.",
+							"verse": 93
+						},
+						{
+							"reference": "D&C 124:94",
+							"text": "And from this time forth I appoint unto him that he may be a prophet, and a seer, and a revelator unto my church, as well as my servant Joseph;",
+							"verse": 94
+						},
+						{
+							"reference": "D&C 124:95",
+							"text": "That he may act in concert also with my servant Joseph; and that he shall receive counsel from my servant Joseph, who shall show unto him the keys whereby he may ask and receive, and be crowned with the same blessing, and glory, and honor, and priesthood, and gifts of the priesthood, that once were put upon him that was my servant Oliver Cowdery;",
+							"verse": 95
+						},
+						{
+							"reference": "D&C 124:96",
+							"text": "That my servant Hyrum may bear record of the things which I shall show unto him, that his name may be had in honorable remembrance from generation to generation, forever and ever.",
+							"verse": 96
+						},
+						{
+							"reference": "D&C 124:97",
+							"text": "Let my servant William Law also receive the keys by which he may ask and receive blessings; let him be humble before me, and be without guile, and he shall receive of my Spirit, even the Comforter, which shall manifest unto him the truth of all things, and shall give him, in the very hour, what he shall say.",
+							"verse": 97
+						},
+						{
+							"reference": "D&C 124:98",
+							"text": "And these signs shall follow him\u2014he shall heal the sick, he shall cast out devils, and shall be delivered from those who would administer unto him deadly poison;",
+							"verse": 98
+						},
+						{
+							"reference": "D&C 124:99",
+							"text": "And he shall be led in paths where the poisonous serpent cannot lay hold upon his heel, and he shall mount up in the imagination of his thoughts as upon eagles' wings.",
+							"verse": 99
+						},
+						{
+							"reference": "D&C 124:100",
+							"text": "And what if I will that he should raise the dead, let him not withhold his voice.",
+							"verse": 100
+						},
+						{
+							"reference": "D&C 124:101",
+							"text": "Therefore, let my servant William cry aloud and spare not, with joy and rejoicing, and with hosannas to him that sitteth upon the throne forever and ever, saith the Lord your God.",
+							"verse": 101
+						},
+						{
+							"reference": "D&C 124:102",
+							"text": "Behold, I say unto you, I have a mission in store for my servant William, and my servant Hyrum, and for them alone; and let my servant Joseph tarry at home, for he is needed. The remainder I will show unto you hereafter. Even so. Amen.",
+							"verse": 102
+						},
+						{
+							"reference": "D&C 124:103",
+							"text": "And again, verily I say unto you, if my servant Sidney will serve me and be counselor unto my servant Joseph, let him arise and come up and stand in the office of his calling, and humble himself before me.",
+							"verse": 103
+						},
+						{
+							"reference": "D&C 124:104",
+							"text": "And if he will offer unto me an acceptable offering, and acknowledgments, and remain with my people, behold, I, the Lord your God, will heal him that he shall be healed; and he shall lift up his voice again on the mountains, and be a spokesman before my face.",
+							"verse": 104
+						},
+						{
+							"reference": "D&C 124:105",
+							"text": "Let him come and locate his family in the neighborhood in which my servant Joseph resides.",
+							"verse": 105
+						},
+						{
+							"reference": "D&C 124:106",
+							"text": "And in all his journeyings let him lift up his voice as with the sound of a trump, and warn the inhabitants of the earth to flee the wrath to come.",
+							"verse": 106
+						},
+						{
+							"reference": "D&C 124:107",
+							"text": "Let him assist my servant Joseph, and also let my servant William Law assist my servant Joseph, in making a solemn proclamation unto the kings of the earth, even as I have before said unto you.",
+							"verse": 107
+						},
+						{
+							"reference": "D&C 124:108",
+							"text": "If my servant Sidney will do my will, let him not remove his family unto the eastern lands, but let him change their habitation, even as I have said.",
+							"verse": 108
+						},
+						{
+							"reference": "D&C 124:109",
+							"text": "Behold, it is not my will that he shall seek to find safety and refuge out of the city which I have appointed unto you, even the city of Nauvoo.",
+							"verse": 109
+						},
+						{
+							"reference": "D&C 124:110",
+							"text": "Verily I say unto you, even now, if he will hearken unto my voice, it shall be well with him. Even so. Amen.",
+							"verse": 110
+						},
+						{
+							"reference": "D&C 124:111",
+							"text": "And again, verily I say unto you, let my servant Amos Davies pay stock into the hands of those whom I have appointed to build a house for boarding, even the Nauvoo House.",
+							"verse": 111
+						},
+						{
+							"reference": "D&C 124:112",
+							"text": "This let him do if he will have an interest; and let him hearken unto the counsel of my servant Joseph, and labor with his own hands that he may obtain the confidence of men.",
+							"verse": 112
+						},
+						{
+							"reference": "D&C 124:113",
+							"text": "And when he shall prove himself faithful in all things that shall be entrusted unto his care, yea, even a few things, he shall be made ruler over many;",
+							"verse": 113
+						},
+						{
+							"reference": "D&C 124:114",
+							"text": "Let him therefore abase himself that he may be exalted. Even so. Amen.",
+							"verse": 114
+						},
+						{
+							"reference": "D&C 124:115",
+							"text": "And again, verily I say unto you, if my servant Robert D. Foster will obey my voice, let him build a house for my servant Joseph, according to the contract which he has made with him, as the door shall be open to him from time to time.",
+							"verse": 115
+						},
+						{
+							"reference": "D&C 124:116",
+							"text": "And let him repent of all his folly, and clothe himself with charity; and cease to do evil, and lay aside all his hard speeches;",
+							"verse": 116
+						},
+						{
+							"reference": "D&C 124:117",
+							"text": "And pay stock also into the hands of the quorum of the Nauvoo House, for himself and for his generation after him, from generation to generation;",
+							"verse": 117
+						},
+						{
+							"reference": "D&C 124:118",
+							"text": "And hearken unto the counsel of my servants Joseph, and Hyrum, and William Law, and unto the authorities which I have called to lay the foundation of Zion; and it shall be well with him forever and ever. Even so. Amen.",
+							"verse": 118
+						},
+						{
+							"reference": "D&C 124:119",
+							"text": "And again, verily I say unto you, let no man pay stock to the quorum of the Nauvoo House unless he shall be a believer in the Book of Mormon, and the revelations I have given unto you, saith the Lord your God;",
+							"verse": 119
+						},
+						{
+							"reference": "D&C 124:120",
+							"text": "For that which is more or less than this cometh of evil, and shall be attended with cursings and not blessings, saith the Lord your God. Even so. Amen.",
+							"verse": 120
+						},
+						{
+							"reference": "D&C 124:121",
+							"text": "And again, verily I say unto you, let the quorum of the Nauvoo House have a just recompense of wages for all their labors which they do in building the Nauvoo House; and let their wages be as shall be agreed among themselves, as pertaining to the price thereof.",
+							"verse": 121
+						},
+						{
+							"reference": "D&C 124:122",
+							"text": "And let every man who pays stock bear his proportion of their wages, if it must needs be, for their support, saith the Lord; otherwise, their labors shall be accounted unto them for stock in that house. Even so. Amen.",
+							"verse": 122
+						},
+						{
+							"reference": "D&C 124:123",
+							"text": "Verily I say unto you, I now give unto you the officers belonging to my Priesthood, that ye may hold the keys thereof, even the Priesthood which is after the order of Melchizedek, which is after the order of mine Only Begotten Son.",
+							"verse": 123
+						},
+						{
+							"reference": "D&C 124:124",
+							"text": "First, I give unto you Hyrum Smith to be a patriarch unto you, to hold the sealing blessings of my church, even the Holy Spirit of promise, whereby ye are sealed up unto the day of redemption, that ye may not fall notwithstanding the hour of temptation that may come upon you.",
+							"verse": 124
+						},
+						{
+							"reference": "D&C 124:125",
+							"text": "I give unto you my servant Joseph to be a presiding elder over all my church, to be a translator, a revelator, a seer, and prophet.",
+							"verse": 125
+						},
+						{
+							"reference": "D&C 124:126",
+							"text": "I give unto him for counselors my servant Sidney Rigdon and my servant William Law, that these may constitute a quorum and First Presidency, to receive the oracles for the whole church.",
+							"verse": 126
+						},
+						{
+							"reference": "D&C 124:127",
+							"text": "I give unto you my servant Brigham Young to be a president over the Twelve traveling council;",
+							"verse": 127
+						},
+						{
+							"reference": "D&C 124:128",
+							"text": "Which Twelve hold the keys to open up the authority of my kingdom upon the four corners of the earth, and after that to send my word to every creature.",
+							"verse": 128
+						},
+						{
+							"reference": "D&C 124:129",
+							"text": "They are Heber C. Kimball, Parley P. Pratt, Orson Pratt, Orson Hyde, William Smith, John Taylor, John E. Page, Wilford Woodruff, Willard Richards, George A. Smith;",
+							"verse": 129
+						},
+						{
+							"reference": "D&C 124:130",
+							"text": "David Patten I have taken unto myself; behold, his priesthood no man taketh from him; but, verily I say unto you, another may be appointed unto the same calling.",
+							"verse": 130
+						},
+						{
+							"reference": "D&C 124:131",
+							"text": "And again, I say unto you, I give unto you a high council, for the cornerstone of Zion\u2014",
+							"verse": 131
+						},
+						{
+							"reference": "D&C 124:132",
+							"text": "Namely, Samuel Bent, Henry G. Sherwood, George W. Harris, Charles C. Rich, Thomas Grover, Newel Knight, David Dort, Dunbar Wilson\u2014Seymour Brunson I have taken unto myself; no man taketh his priesthood, but another may be appointed unto the same priesthood in his stead; and verily I say unto you, let my servant Aaron Johnson be ordained unto this calling in his stead\u2014David Fullmer, Alpheus Cutler, William Huntington.",
+							"verse": 132
+						},
+						{
+							"reference": "D&C 124:133",
+							"text": "And again, I give unto you Don C. Smith to be a president over a quorum of high priests;",
+							"verse": 133
+						},
+						{
+							"reference": "D&C 124:134",
+							"text": "Which ordinance is instituted for the purpose of qualifying those who shall be appointed standing presidents or servants over different stakes scattered abroad;",
+							"verse": 134
+						},
+						{
+							"reference": "D&C 124:135",
+							"text": "And they may travel also if they choose, but rather be ordained for standing presidents; this is the office of their calling, saith the Lord your God.",
+							"verse": 135
+						},
+						{
+							"reference": "D&C 124:136",
+							"text": "I give unto him Amasa Lyman and Noah Packard for counselors, that they may preside over the quorum of high priests of my church, saith the Lord.",
+							"verse": 136
+						},
+						{
+							"reference": "D&C 124:137",
+							"text": "And again, I say unto you, I give unto you John A. Hicks, Samuel Williams, and Jesse Baker, which priesthood is to preside over the quorum of elders, which quorum is instituted for standing ministers; nevertheless they may travel, yet they are ordained to be standing ministers to my church, saith the Lord.",
+							"verse": 137
+						},
+						{
+							"reference": "D&C 124:138",
+							"text": "And again, I give unto you Joseph Young, Josiah Butterfield, Daniel Miles, Henry Herriman, Zera Pulsipher, Levi Hancock, James Foster, to preside over the quorum of seventies;",
+							"verse": 138
+						},
+						{
+							"reference": "D&C 124:139",
+							"text": "Which quorum is instituted for traveling elders to bear record of my name in all the world, wherever the traveling high council, mine apostles, shall send them to prepare a way before my face.",
+							"verse": 139
+						},
+						{
+							"reference": "D&C 124:140",
+							"text": "The difference between this quorum and the quorum of elders is that one is to travel continually, and the other is to preside over the churches from time to time; the one has the responsibility of presiding from time to time, and the other has no responsibility of presiding, saith the Lord your God.",
+							"verse": 140
+						},
+						{
+							"reference": "D&C 124:141",
+							"text": "And again, I say unto you, I give unto you Vinson Knight, Samuel H. Smith, and Shadrach Roundy, if he will receive it, to preside over the bishopric; a knowledge of said bishopric is given unto you in the book of Doctrine and Covenants.",
+							"verse": 141
+						},
+						{
+							"reference": "D&C 124:142",
+							"text": "And again, I say unto you, Samuel Rolfe and his counselors for priests, and the president of the teachers and his counselors, and also the president of the deacons and his counselors, and also the president of the stake and his counselors.",
+							"verse": 142
+						},
+						{
+							"reference": "D&C 124:143",
+							"text": "The above offices I have given unto you, and the keys thereof, for helps and for governments, for the work of the ministry and the perfecting of my saints.",
+							"verse": 143
+						},
+						{
+							"reference": "D&C 124:144",
+							"text": "And a commandment I give unto you, that you should fill all these offices and approve of those names which I have mentioned, or else disapprove of them at my general conference;",
+							"verse": 144
+						},
+						{
+							"reference": "D&C 124:145",
+							"text": "And that ye should prepare rooms for all these offices in my house when you build it unto my name, saith the Lord your God. Even so. Amen.",
+							"verse": 145
+						}
+					]
+				},
+				{
+					"chapter": 125,
+					"reference": "D&C 125",
+					"verses": [{
+							"reference": "D&C 125:1",
+							"text": "What is the will of the Lord concerning the saints in the Territory of Iowa?",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 125:2",
+							"text": "Verily, thus saith the Lord, I say unto you, if those who call themselves by my name and are essaying to be my saints, if they will do my will and keep my commandments concerning them, let them gather themselves together unto the places which I shall appoint unto them by my servant Joseph, and build up cities unto my name, that they may be prepared for that which is in store for a time to come.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 125:3",
+							"text": "Let them build up a city unto my name upon the land opposite the city of Nauvoo, and let the name of Zarahemla be named upon it.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 125:4",
+							"text": "And let all those who come from the east, and the west, and the north, and the south, that have desires to dwell therein, take up their inheritance in the same, as well as in the city of Nashville, or in the city of Nauvoo, and in all the stakes which I have appointed, saith the Lord.",
+							"verse": 4
+						}
+					]
+				}
+			]
+		},
+		{
+			"book": "D&C 126-138",
+			"chapters": [{
+					"chapter": 126,
+					"reference": "D&C 126",
+					"verses": [{
+							"reference": "D&C 126:1",
+							"text": "Dear and well-beloved brother, Brigham Young, verily thus saith the Lord unto you: My servant Brigham, it is no more required at your hand to leave your family as in times past, for your offering is acceptable to me.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 126:2",
+							"text": "I have seen your labor and toil in journeyings for my name.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 126:3",
+							"text": "I therefore command you to send my word abroad, and take especial care of your family from this time, henceforth and forever. Amen.",
+							"verse": 3
+						}
+					]
+				},
+				{
+					"chapter": 127,
+					"reference": "D&C 127",
+					"signature": "Joseph Smith.",
+					"verses": [{
+							"reference": "D&C 127:1",
+							"text": "Forasmuch as the Lord has revealed unto me that my enemies, both in Missouri and this State, were again in the pursuit of me; and inasmuch as they pursue me without a cause, and have not the least shadow or coloring of justice or right on their side in the getting up of their prosecutions against me; and inasmuch as their pretensions are all founded in falsehood of the blackest dye, I have thought it expedient and wisdom in me to leave the place for a short season, for my own safety and the safety of this people. I would say to all those with whom I have business, that I have left my affairs with agents and clerks who will transact all business in a prompt and proper manner, and will see that all my debts are canceled in due time, by turning out property, or otherwise, as the case may require, or as the circumstances may admit of. When I learn that the storm is fully blown over, then I will return to you again.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 127:2",
+							"text": "And as for the perils which I am called to pass through, they seem but a small thing to me, as the envy and wrath of man have been my common lot all the days of my life; and for what cause it seems mysterious, unless I was ordained from before the foundation of the world for some good end, or bad, as you may choose to call it. Judge ye for yourselves. God knoweth all these things, whether it be good or bad. But nevertheless, deep water is what I am wont to swim in. It all has become a second nature to me; and I feel, like Paul, to glory in tribulation; for to this day has the God of my fathers delivered me out of them all, and will deliver me from henceforth; for behold, and lo, I shall triumph over all my enemies, for the Lord God hath spoken it.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 127:3",
+							"text": "Let all the saints rejoice, therefore, and be exceedingly glad; for Israel's God is their God, and he will mete out a just recompense of reward upon the heads of all their oppressors.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 127:4",
+							"text": "And again, verily thus saith the Lord: Let the work of my temple, and all the works which I have appointed unto you, be continued on and not cease; and let your diligence, and your perseverance, and patience, and your works be redoubled, and you shall in nowise lose your reward, saith the Lord of Hosts. And if they persecute you, so persecuted they the prophets and righteous men that were before you. For all this there is a reward in heaven.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 127:5",
+							"text": "And again, I give unto you a word in relation to the baptism for your dead.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 127:6",
+							"text": "Verily, thus saith the Lord unto you concerning your dead: When any of you are baptized for your dead, let there be a recorder, and let him be eye-witness of your baptisms; let him hear with his ears, that he may testify of a truth, saith the Lord;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 127:7",
+							"text": "That in all your recordings it may be recorded in heaven; whatsoever you bind on earth, may be bound in heaven; whatsoever you loose on earth, may be loosed in heaven;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 127:8",
+							"text": "For I am about to restore many things to the earth, pertaining to the priesthood, saith the Lord of Hosts.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 127:9",
+							"text": "And again, let all the records be had in order, that they may be put in the archives of my holy temple, to be held in remembrance from generation to generation, saith the Lord of Hosts.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 127:10",
+							"text": "I will say to all the saints, that I desired, with exceedingly great desire, to have addressed them from the stand on the subject of baptism for the dead, on the following Sabbath. But inasmuch as it is out of my power to do so, I will write the word of the Lord from time to time, on that subject, and send it to you by mail, as well as many other things.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 127:11",
+							"text": "I now close my letter for the present, for the want of more time; for the enemy is on the alert, and as the Savior said, the prince of this world cometh, but he hath nothing in me.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 127:12",
+							"text": "Behold, my prayer to God is that you all may be saved. And I subscribe myself your servant in the Lord, prophet and seer of The Church of Jesus Christ of Latter-day Saints.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 128,
+					"reference": "D&C 128",
+					"signature": "Joseph Smith.",
+					"verses": [{
+							"reference": "D&C 128:1",
+							"text": "As I stated to you in my letter before I left my place, that I would write to you from time to time and give you information in relation to many subjects, I now resume the subject of the baptism for the dead, as that subject seems to occupy my mind, and press itself upon my feelings the strongest, since I have been pursued by my enemies.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 128:2",
+							"text": "I wrote a few words of revelation to you concerning a recorder. I have had a few additional views in relation to this matter, which I now certify. That is, it was declared in my former letter that there should be a recorder, who should be eye-witness, and also to hear with his ears, that he might make a record of a truth before the Lord.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 128:3",
+							"text": "Now, in relation to this matter, it would be very difficult for one recorder to be present at all times, and to do all the business. To obviate this difficulty, there can be a recorder appointed in each ward of the city, who is well qualified for taking accurate minutes; and let him be very particular and precise in taking the whole proceedings, certifying in his record that he saw with his eyes, and heard with his ears, giving the date, and names, and so forth, and the history of the whole transaction; naming also some three individuals that are present, if there be any present, who can at any time when called upon certify to the same, that in the mouth of two or three witnesses every word may be established.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 128:4",
+							"text": "Then, let there be a general recorder, to whom these other records can be handed, being attended with certificates over their own signatures, certifying that the record they have made is true. Then the general church recorder can enter the record on the general church book, with the certificates and all the attending witnesses, with his own statement that he verily believes the above statement and records to be true, from his knowledge of the general character and appointment of those men by the church. And when this is done on the general church book, the record shall be just as holy, and shall answer the ordinance just the same as if he had seen with his eyes and heard with his ears, and made a record of the same on the general church book.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 128:5",
+							"text": "You may think this order of things to be very particular; but let me tell you that it is only to answer the will of God, by conforming to the ordinance and preparation that the Lord ordained and prepared before the foundation of the world, for the salvation of the dead who should die without a knowledge of the gospel.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 128:6",
+							"text": "And further, I want you to remember that John the Revelator was contemplating this very subject in relation to the dead, when he declared, as you will find recorded in Revelation 20:12\u2014And I saw the dead, small and great, stand before God; and the books were opened; and another book was opened, which is the book of life; and the dead were judged out of those things which were written in the books, according to their works.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 128:7",
+							"text": "You will discover in this quotation that the books were opened; and another book was opened, which was the book of life; but the dead were judged out of those things which were written in the books, according to their works; consequently, the books spoken of must be the books which contained the record of their works, and refer to the records which are kept on the earth. And the book which was the book of life is the record which is kept in heaven; the principle agreeing precisely with the doctrine which is commanded you in the revelation contained in the letter which I wrote to you previous to my leaving my place\u2014that in all your recordings it may be recorded in heaven.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 128:8",
+							"text": "Now, the nature of this ordinance consists in the power of the priesthood, by the revelation of Jesus Christ, wherein it is granted that whatsoever you bind on earth shall be bound in heaven, and whatsoever you loose on earth shall be loosed in heaven. Or, in other words, taking a different view of the translation, whatsoever you record on earth shall be recorded in heaven, and whatsoever you do not record on earth shall not be recorded in heaven; for out of the books shall your dead be judged, according to their own works, whether they themselves have attended to the ordinances in their own propria persona, or by the means of their own agents, according to the ordinance which God has prepared for their salvation from before the foundation of the world, according to the records which they have kept concerning their dead.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 128:9",
+							"text": "It may seem to some to be a very bold doctrine that we talk of\u2014a power which records or binds on earth and binds in heaven. Nevertheless, in all ages of the world, whenever the Lord has given a dispensation of the priesthood to any man by actual revelation, or any set of men, this power has always been given. Hence, whatsoever those men did in authority, in the name of the Lord, and did it truly and faithfully, and kept a proper and faithful record of the same, it became a law on earth and in heaven, and could not be annulled, according to the decrees of the great Jehovah. This is a faithful saying. Who can hear it?",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 128:10",
+							"text": "And again, for the precedent, Matthew 16:18, 19: And I say also unto thee, That thou art Peter, and upon this rock I will build my church; and the gates of hell shall not prevail against it. And I will give unto thee the keys of the kingdom of heaven: and whatsoever thou shalt bind on earth shall be bound in heaven; and whatsoever thou shalt loose on earth shall be loosed in heaven.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 128:11",
+							"text": "Now the great and grand secret of the whole matter, and the summum bonum of the whole subject that is lying before us, consists in obtaining the powers of the Holy Priesthood. For him to whom these keys are given there is no difficulty in obtaining a knowledge of facts in relation to the salvation of the children of men, both as well for the dead as for the living.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 128:12",
+							"text": "Herein is glory and honor, and immortality and eternal life\u2014The ordinance of baptism by water, to be immersed therein in order to answer to the likeness of the dead, that one principle might accord with the other; to be immersed in the water and come forth out of the water is in the likeness of the resurrection of the dead in coming forth out of their graves; hence, this ordinance was instituted to form a relationship with the ordinance of baptism for the dead, being in likeness of the dead.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 128:13",
+							"text": "Consequently, the baptismal font was instituted as a similitude of the grave, and was commanded to be in a place underneath where the living are wont to assemble, to show forth the living and the dead, and that all things may have their likeness, and that they may accord one with another\u2014that which is earthly conforming to that which is heavenly, as Paul hath declared, 1 Corinthians 15:46, 47, and 48:",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 128:14",
+							"text": "Howbeit that was not first which is spiritual, but that which is natural; and afterward that which is spiritual. The first man is of the earth, earthy; the second man is the Lord from heaven. As is the earthy, such are they also that are earthy; and as is the heavenly, such are they also that are heavenly. And as are the records on the earth in relation to your dead, which are truly made out, so also are the records in heaven. This, therefore, is the sealing and binding power, and, in one sense of the word, the keys of the kingdom, which consist in the key of knowledge.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 128:15",
+							"text": "And now, my dearly beloved brethren and sisters, let me assure you that these are principles in relation to the dead and the living that cannot be lightly passed over, as pertaining to our salvation. For their salvation is necessary and essential to our salvation, as Paul says concerning the fathers\u2014that they without us cannot be made perfect\u2014neither can we without our dead be made perfect.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 128:16",
+							"text": "And now, in relation to the baptism for the dead, I will give you another quotation of Paul, 1 Corinthians 15:29: Else what shall they do which are baptized for the dead, if the dead rise not at all? Why are they then baptized for the dead?",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 128:17",
+							"text": "And again, in connection with this quotation I will give you a quotation from one of the prophets, who had his eye fixed on the restoration of the priesthood, the glories to be revealed in the last days, and in an especial manner this most glorious of all subjects belonging to the everlasting gospel, namely, the baptism for the dead; for Malachi says, last chapter, verses 5th and 6th: Behold, I will send you Elijah the prophet before the coming of the great and dreadful day of the Lord: And he shall turn the heart of the fathers to the children, and the heart of the children to their fathers, lest I come and smite the earth with a curse.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 128:18",
+							"text": "I might have rendered a plainer translation to this, but it is sufficiently plain to suit my purpose as it stands. It is sufficient to know, in this case, that the earth will be smitten with a curse unless there is a welding link of some kind or other between the fathers and the children, upon some subject or other\u2014and behold what is that subject? It is the baptism for the dead. For we without them cannot be made perfect; neither can they without us be made perfect. Neither can they nor we be made perfect without those who have died in the gospel also; for it is necessary in the ushering in of the dispensation of the fulness of times, which dispensation is now beginning to usher in, that a whole and complete and perfect union, and welding together of dispensations, and keys, and powers, and glories should take place, and be revealed from the days of Adam even to the present time. And not only this, but those things which never have been revealed from the foundation of the world, but have been kept hid from the wise and prudent, shall be revealed unto babes and sucklings in this, the dispensation of the fulness of times.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 128:19",
+							"text": "Now, what do we hear in the gospel which we have received? A voice of gladness! A voice of mercy from heaven; and a voice of truth out of the earth; glad tidings for the dead; a voice of gladness for the living and the dead; glad tidings of great joy. How beautiful upon the mountains are the feet of those that bring glad tidings of good things, and that say unto Zion: Behold, thy God reigneth! As the dews of Carmel, so shall the knowledge of God descend upon them!",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 128:20",
+							"text": "And again, what do we hear? Glad tidings from Cumorah! Moroni, an angel from heaven, declaring the fulfilment of the prophets\u2014the book to be revealed. A voice of the Lord in the wilderness of Fayette, Seneca county, declaring the three witnesses to bear record of the book! The voice of Michael on the banks of the Susquehanna, detecting the devil when he appeared as an angel of light! The voice of Peter, James, and John in the wilderness between Harmony, Susquehanna county, and Colesville, Broome county, on the Susquehanna river, declaring themselves as possessing the keys of the kingdom, and of the dispensation of the fulness of times!",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 128:21",
+							"text": "And again, the voice of God in the chamber of old Father Whitmer, in Fayette, Seneca county, and at sundry times, and in divers places through all the travels and tribulations of this Church of Jesus Christ of Latter-day Saints! And the voice of Michael, the archangel; the voice of Gabriel, and of Raphael, and of divers angels, from Michael or Adam down to the present time, all declaring their dispensation, their rights, their keys, their honors, their majesty and glory, and the power of their priesthood; giving line upon line, precept upon precept; here a little, and there a little; giving us consolation by holding forth that which is to come, confirming our hope!",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 128:22",
+							"text": "Brethren, shall we not go on in so great a cause? Go forward and not backward. Courage, brethren; and on, on to the victory! Let your hearts rejoice, and be exceedingly glad. Let the earth break forth into singing. Let the dead speak forth anthems of eternal praise to the King Immanuel, who hath ordained, before the world was, that which would enable us to redeem them out of their prison; for the prisoners shall go free.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 128:23",
+							"text": "Let the mountains shout for joy, and all ye valleys cry aloud; and all ye seas and dry lands tell the wonders of your Eternal King! And ye rivers, and brooks, and rills, flow down with gladness. Let the woods and all the trees of the field praise the Lord; and ye solid rocks weep for joy! And let the sun, moon, and the morning stars sing together, and let all the sons of God shout for joy! And let the eternal creations declare his name forever and ever! And again I say, how glorious is the voice we hear from heaven, proclaiming in our ears, glory, and salvation, and honor, and immortality, and eternal life; kingdoms, principalities, and powers!",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 128:24",
+							"text": "Behold, the great day of the Lord is at hand; and who can abide the day of his coming, and who can stand when he appeareth? For he is like a refiner's fire, and like fuller's soap; and he shall sit as a refiner and purifier of silver, and he shall purify the sons of Levi, and purge them as gold and silver, that they may offer unto the Lord an offering in righteousness. Let us, therefore, as a church and a people, and as Latter-day Saints, offer unto the Lord an offering in righteousness; and let us present in his holy temple, when it is finished, a book containing the records of our dead, which shall be worthy of all acceptation.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 128:25",
+							"text": "Brethren, I have many things to say to you on the subject; but shall now close for the present, and continue the subject another time. I am, as ever, your humble servant and never deviating friend,",
+							"verse": 25
+						}
+					]
+				},
+				{
+					"chapter": 129,
+					"reference": "D&C 129",
+					"verses": [{
+							"reference": "D&C 129:1",
+							"text": "There are two kinds of beings in heaven, namely: Angels, who are resurrected personages, having bodies of flesh and bones\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 129:2",
+							"text": "For instance, Jesus said: Handle me and see, for a spirit hath not flesh and bones, as ye see me have.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 129:3",
+							"text": "Secondly: the spirits of just men made perfect, they who are not resurrected, but inherit the same glory.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 129:4",
+							"text": "When a messenger comes saying he has a message from God, offer him your hand and request him to shake hands with you.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 129:5",
+							"text": "If he be an angel he will do so, and you will feel his hand.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 129:6",
+							"text": "If he be the spirit of a just man made perfect he will come in his glory; for that is the only way he can appear\u2014",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 129:7",
+							"text": "Ask him to shake hands with you, but he will not move, because it is contrary to the order of heaven for a just man to deceive; but he will still deliver his message.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 129:8",
+							"text": "If it be the devil as an angel of light, when you ask him to shake hands he will offer you his hand, and you will not feel anything; you may therefore detect him.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 129:9",
+							"text": "These are three grand keys whereby you may know whether any administration is from God.",
+							"verse": 9
+						}
+					]
+				},
+				{
+					"chapter": 130,
+					"reference": "D&C 130",
+					"verses": [{
+							"reference": "D&C 130:1",
+							"text": "When the Savior shall appear we shall see him as he is. We shall see that he is a man like ourselves.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 130:2",
+							"text": "And that same sociality which exists among us here will exist among us there, only it will be coupled with eternal glory, which glory we do not now enjoy.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 130:3",
+							"text": "John 14:23\u2014The appearing of the Father and the Son, in that verse, is a personal appearance; and the idea that the Father and the Son dwell in a man's heart is an old sectarian notion, and is false.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 130:4",
+							"text": "In answer to the question\u2014Is not the reckoning of God's time, angel's time, prophet's time, and man's time, according to the planet on which they reside?",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 130:5",
+							"text": "I answer, Yes. But there are no angels who minister to this earth but those who do belong or have belonged to it.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 130:6",
+							"text": "The angels do not reside on a planet like this earth;",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 130:7",
+							"text": "But they reside in the presence of God, on a globe like a sea of glass and fire, where all things for their glory are manifest, past, present, and future, and are continually before the Lord.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 130:8",
+							"text": "The place where God resides is a great Urim and Thummim.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 130:9",
+							"text": "This earth, in its sanctified and immortal state, will be made like unto crystal and will be a Urim and Thummim to the inhabitants who dwell thereon, whereby all things pertaining to an inferior kingdom, or all kingdoms of a lower order, will be manifest to those who dwell on it; and this earth will be Christ's.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 130:10",
+							"text": "Then the white stone mentioned in Revelation 2:17, will become a Urim and Thummim to each individual who receives one, whereby things pertaining to a higher order of kingdoms will be made known;",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 130:11",
+							"text": "And a white stone is given to each of those who come into the celestial kingdom, whereon is a new name written, which no man knoweth save he that receiveth it. The new name is the key word.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 130:12",
+							"text": "I prophesy, in the name of the Lord God, that the commencement of the difficulties which will cause much bloodshed previous to the coming of the Son of Man will be in South Carolina.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 130:13",
+							"text": "It may probably arise through the slave question. This a voice declared to me, while I was praying earnestly on the subject, December 25th, 1832.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 130:14",
+							"text": "I was once praying very earnestly to know the time of the coming of the Son of Man, when I heard a voice repeat the following:",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 130:15",
+							"text": "Joseph, my son, if thou livest until thou art eighty-five years old, thou shalt see the face of the Son of Man; therefore let this suffice, and trouble me no more on this matter.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 130:16",
+							"text": "I was left thus, without being able to decide whether this coming referred to the beginning of the millennium or to some previous appearing, or whether I should die and thus see his face.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 130:17",
+							"text": "I believe the coming of the Son of Man will not be any sooner than that time.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 130:18",
+							"text": "Whatever principle of intelligence we attain unto in this life, it will rise with us in the resurrection.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 130:19",
+							"text": "And if a person gains more knowledge and intelligence in this life through his diligence and obedience than another, he will have so much the advantage in the world to come.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 130:20",
+							"text": "There is a law, irrevocably decreed in heaven before the foundations of this world, upon which all blessings are predicated\u2014",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 130:21",
+							"text": "And when we obtain any blessing from God, it is by obedience to that law upon which it is predicated.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 130:22",
+							"text": "The Father has a body of flesh and bones as tangible as man's; the Son also; but the Holy Ghost has not a body of flesh and bones, but is a personage of Spirit. Were it not so, the Holy Ghost could not dwell in us.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 130:23",
+							"text": "A man may receive the Holy Ghost, and it may descend upon him and not tarry with him.",
+							"verse": 23
+						}
+					]
+				},
+				{
+					"chapter": 131,
+					"reference": "D&C 131",
+					"verses": [{
+							"reference": "D&C 131:1",
+							"text": "In the celestial glory there are three heavens or degrees;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 131:2",
+							"text": "And in order to obtain the highest, a man must enter into this order of the priesthood [meaning the new and everlasting covenant of marriage];",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 131:3",
+							"text": "And if he does not, he cannot obtain it.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 131:4",
+							"text": "He may enter into the other, but that is the end of his kingdom; he cannot have an increase.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 131:5",
+							"text": "(May 17th, 1843.) The more sure word of prophecy means a man's knowing that he is sealed up unto eternal life, by revelation and the spirit of prophecy, through the power of the Holy Priesthood.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 131:6",
+							"text": "It is impossible for a man to be saved in ignorance.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 131:7",
+							"text": "There is no such thing as immaterial matter. All spirit is matter, but it is more fine or pure, and can only be discerned by purer eyes;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 131:8",
+							"text": "We cannot see it; but when our bodies are purified we shall see that it is all matter.",
+							"verse": 8
+						}
+					]
+				},
+				{
+					"chapter": 132,
+					"reference": "D&C 132",
+					"verses": [{
+							"reference": "D&C 132:1",
+							"text": "Verily, thus saith the Lord unto you my servant Joseph, that inasmuch as you have inquired of my hand to know and understand wherein I, the Lord, justified my servants Abraham, Isaac, and Jacob, as also Moses, David and Solomon, my servants, as touching the principle and doctrine of their having many wives and concubines\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 132:2",
+							"text": "Behold, and lo, I am the Lord thy God, and will answer thee as touching this matter.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 132:3",
+							"text": "Therefore, prepare thy heart to receive and obey the instructions which I am about to give unto you; for all those who have this law revealed unto them must obey the same.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 132:4",
+							"text": "For behold, I reveal unto you a new and an everlasting covenant; and if ye abide not that covenant, then are ye damned; for no one can reject this covenant and be permitted to enter into my glory.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 132:5",
+							"text": "For all who will have a blessing at my hands shall abide the law which was appointed for that blessing, and the conditions thereof, as were instituted from before the foundation of the world.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 132:6",
+							"text": "And as pertaining to the new and everlasting covenant, it was instituted for the fulness of my glory; and he that receiveth a fulness thereof must and shall abide the law, or he shall be damned, saith the Lord God.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 132:7",
+							"text": "And verily I say unto you, that the conditions of this law are these: All covenants, contracts, bonds, obligations, oaths, vows, performances, connections, associations, or expectations, that are not made and entered into and sealed by the Holy Spirit of promise, of him who is anointed, both as well for time and for all eternity, and that too most holy, by revelation and commandment through the medium of mine anointed, whom I have appointed on the earth to hold this power (and I have appointed unto my servant Joseph to hold this power in the last days, and there is never but one on the earth at a time on whom this power and the keys of this priesthood are conferred), are of no efficacy, virtue, or force in and after the resurrection from the dead; for all contracts that are not made unto this end have an end when men are dead.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 132:8",
+							"text": "Behold, mine house is a house of order, saith the Lord God, and not a house of confusion.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 132:9",
+							"text": "Will I accept of an offering, saith the Lord, that is not made in my name?",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 132:10",
+							"text": "Or will I receive at your hands that which I have not appointed?",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 132:11",
+							"text": "And will I appoint unto you, saith the Lord, except it be by law, even as I and my Father ordained unto you, before the world was?",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 132:12",
+							"text": "I am the Lord thy God; and I give unto you this commandment\u2014that no man shall come unto the Father but by me or by my word, which is my law, saith the Lord.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 132:13",
+							"text": "And everything that is in the world, whether it be ordained of men, by thrones, or principalities, or powers, or things of name, whatsoever they may be, that are not by me or by my word, saith the Lord, shall be thrown down, and shall not remain after men are dead, neither in nor after the resurrection, saith the Lord your God.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 132:14",
+							"text": "For whatsoever things remain are by me; and whatsoever things are not by me shall be shaken and destroyed.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 132:15",
+							"text": "Therefore, if a man marry him a wife in the world, and he marry her not by me nor by my word, and he covenant with her so long as he is in the world and she with him, their covenant and marriage are not of force when they are dead, and when they are out of the world; therefore, they are not bound by any law when they are out of the world.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 132:16",
+							"text": "Therefore, when they are out of the world they neither marry nor are given in marriage; but are appointed angels in heaven, which angels are ministering servants, to minister for those who are worthy of a far more, and an exceeding, and an eternal weight of glory.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 132:17",
+							"text": "For these angels did not abide my law; therefore, they cannot be enlarged, but remain separately and singly, without exaltation, in their saved condition, to all eternity; and from henceforth are not gods, but are angels of God forever and ever.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 132:18",
+							"text": "And again, verily I say unto you, if a man marry a wife, and make a covenant with her for time and for all eternity, if that covenant is not by me or by my word, which is my law, and is not sealed by the Holy Spirit of promise, through him whom I have anointed and appointed unto this power, then it is not valid neither of force when they are out of the world, because they are not joined by me, saith the Lord, neither by my word; when they are out of the world it cannot be received there, because the angels and the gods are appointed there, by whom they cannot pass; they cannot, therefore, inherit my glory; for my house is a house of order, saith the Lord God.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 132:19",
+							"text": "And again, verily I say unto you, if a man marry a wife by my word, which is my law, and by the new and everlasting covenant, and it is sealed unto them by the Holy Spirit of promise, by him who is anointed, unto whom I have appointed this power and the keys of this priesthood; and it shall be said unto them\u2014Ye shall come forth in the first resurrection; and if it be after the first resurrection, in the next resurrection; and shall inherit thrones, kingdoms, principalities, and powers, dominions, all heights and depths\u2014then shall it be written in the Lamb's Book of Life, that he shall commit no murder whereby to shed innocent blood, and if ye abide in my covenant, and commit no murder whereby to shed innocent blood, it shall be done unto them in all things whatsoever my servant hath put upon them, in time, and through all eternity; and shall be of full force when they are out of the world; and they shall pass by the angels, and the gods, which are set there, to their exaltation and glory in all things, as hath been sealed upon their heads, which glory shall be a fulness and a continuation of the seeds forever and ever.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 132:20",
+							"text": "Then shall they be gods, because they have no end; therefore shall they be from everlasting to everlasting, because they continue; then shall they be above all, because all things are subject unto them. Then shall they be gods, because they have all power, and the angels are subject unto them.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 132:21",
+							"text": "Verily, verily, I say unto you, except ye abide my law ye cannot attain to this glory.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 132:22",
+							"text": "For strait is the gate, and narrow the way that leadeth unto the exaltation and continuation of the lives, and few there be that find it, because ye receive me not in the world neither do ye know me.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 132:23",
+							"text": "But if ye receive me in the world, then shall ye know me, and shall receive your exaltation; that where I am ye shall be also.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 132:24",
+							"text": "This is eternal lives\u2014to know the only wise and true God, and Jesus Christ, whom he hath sent. I am he. Receive ye, therefore, my law.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 132:25",
+							"text": "Broad is the gate, and wide the way that leadeth to the deaths; and many there are that go in thereat, because they receive me not, neither do they abide in my law.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 132:26",
+							"text": "Verily, verily, I say unto you, if a man marry a wife according to my word, and they are sealed by the Holy Spirit of promise, according to mine appointment, and he or she shall commit any sin or transgression of the new and everlasting covenant whatever, and all manner of blasphemies, and if they commit no murder wherein they shed innocent blood, yet they shall come forth in the first resurrection, and enter into their exaltation; but they shall be destroyed in the flesh, and shall be delivered unto the buffetings of Satan unto the day of redemption, saith the Lord God.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 132:27",
+							"text": "The blasphemy against the Holy Ghost, which shall not be forgiven in the world nor out of the world, is in that ye commit murder wherein ye shed innocent blood, and assent unto my death, after ye have received my new and everlasting covenant, saith the Lord God; and he that abideth not this law can in nowise enter into my glory, but shall be damned, saith the Lord.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 132:28",
+							"text": "I am the Lord thy God, and will give unto thee the law of my Holy Priesthood, as was ordained by me and my Father before the world was.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 132:29",
+							"text": "Abraham received all things, whatsoever he received, by revelation and commandment, by my word, saith the Lord, and hath entered into his exaltation and sitteth upon his throne.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 132:30",
+							"text": "Abraham received promises concerning his seed, and of the fruit of his loins\u2014from whose loins ye are, namely, my servant Joseph\u2014which were to continue so long as they were in the world; and as touching Abraham and his seed, out of the world they should continue; both in the world and out of the world should they continue as innumerable as the stars; or, if ye were to count the sand upon the seashore ye could not number them.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 132:31",
+							"text": "This promise is yours also, because ye are of Abraham, and the promise was made unto Abraham; and by this law is the continuation of the works of my Father, wherein he glorifieth himself.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 132:32",
+							"text": "Go ye, therefore, and do the works of Abraham; enter ye into my law and ye shall be saved.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 132:33",
+							"text": "But if ye enter not into my law ye cannot receive the promise of my Father, which he made unto Abraham.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 132:34",
+							"text": "God commanded Abraham, and Sarah gave Hagar to Abraham to wife. And why did she do it? Because this was the law; and from Hagar sprang many people. This, therefore, was fulfilling, among other things, the promises.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 132:35",
+							"text": "Was Abraham, therefore, under condemnation? Verily I say unto you, Nay; for I, the Lord, commanded it.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 132:36",
+							"text": "Abraham was commanded to offer his son Isaac; nevertheless, it was written: Thou shalt not kill. Abraham, however, did not refuse, and it was accounted unto him for righteousness.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 132:37",
+							"text": "Abraham received concubines, and they bore him children; and it was accounted unto him for righteousness, because they were given unto him, and he abode in my law; as Isaac also and Jacob did none other things than that which they were commanded; and because they did none other things than that which they were commanded, they have entered into their exaltation, according to the promises, and sit upon thrones, and are not angels but are gods.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 132:38",
+							"text": "David also received many wives and concubines, and also Solomon and Moses my servants, as also many others of my servants, from the beginning of creation until this time; and in nothing did they sin save in those things which they received not of me.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 132:39",
+							"text": "David's wives and concubines were given unto him of me, by the hand of Nathan, my servant, and others of the prophets who had the keys of this power; and in none of these things did he sin against me save in the case of Uriah and his wife; and, therefore he hath fallen from his exaltation, and received his portion; and he shall not inherit them out of the world, for I gave them unto another, saith the Lord.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 132:40",
+							"text": "I am the Lord thy God, and I gave unto thee, my servant Joseph, an appointment, and restore all things. Ask what ye will, and it shall be given unto you according to my word.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 132:41",
+							"text": "And as ye have asked concerning adultery, verily, verily, I say unto you, if a man receiveth a wife in the new and everlasting covenant, and if she be with another man, and I have not appointed unto her by the holy anointing, she hath committed adultery and shall be destroyed.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 132:42",
+							"text": "If she be not in the new and everlasting covenant, and she be with another man, she has committed adultery.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 132:43",
+							"text": "And if her husband be with another woman, and he was under a vow, he hath broken his vow and hath committed adultery.",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 132:44",
+							"text": "And if she hath not committed adultery, but is innocent and hath not broken her vow, and she knoweth it, and I reveal it unto you, my servant Joseph, then shall you have power, by the power of my Holy Priesthood, to take her and give her unto him that hath not committed adultery but hath been faithful; for he shall be made ruler over many.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 132:45",
+							"text": "For I have conferred upon you the keys and power of the priesthood, wherein I restore all things, and make known unto you all things in due time.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 132:46",
+							"text": "And verily, verily, I say unto you, that whatsoever you seal on earth shall be sealed in heaven; and whatsoever you bind on earth, in my name and by my word, saith the Lord, it shall be eternally bound in the heavens; and whosesoever sins you remit on earth shall be remitted eternally in the heavens; and whosesoever sins you retain on earth shall be retained in heaven.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 132:47",
+							"text": "And again, verily I say, whomsoever you bless I will bless, and whomsoever you curse I will curse, saith the Lord; for I, the Lord, am thy God.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 132:48",
+							"text": "And again, verily I say unto you, my servant Joseph, that whatsoever you give on earth, and to whomsoever you give any one on earth, by my word and according to my law, it shall be visited with blessings and not cursings, and with my power, saith the Lord, and shall be without condemnation on earth and in heaven.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 132:49",
+							"text": "For I am the Lord thy God, and will be with thee even unto the end of the world, and through all eternity; for verily I seal upon you your exaltation, and prepare a throne for you in the kingdom of my Father, with Abraham your father.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 132:50",
+							"text": "Behold, I have seen your sacrifices, and will forgive all your sins; I have seen your sacrifices in obedience to that which I have told you. Go, therefore, and I make a way for your escape, as I accepted the offering of Abraham of his son Isaac.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 132:51",
+							"text": "Verily, I say unto you: A commandment I give unto mine handmaid, Emma Smith, your wife, whom I have given unto you, that she stay herself and partake not of that which I commanded you to offer unto her; for I did it, saith the Lord, to prove you all, as I did Abraham, and that I might require an offering at your hand, by covenant and sacrifice.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 132:52",
+							"text": "And let mine handmaid, Emma Smith, receive all those that have been given unto my servant Joseph, and who are virtuous and pure before me; and those who are not pure, and have said they were pure, shall be destroyed, saith the Lord God.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 132:53",
+							"text": "For I am the Lord thy God, and ye shall obey my voice; and I give unto my servant Joseph that he shall be made ruler over many things; for he hath been faithful over a few things, and from henceforth I will strengthen him.",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 132:54",
+							"text": "And I command mine handmaid, Emma Smith, to abide and cleave unto my servant Joseph, and to none else. But if she will not abide this commandment she shall be destroyed, saith the Lord; for I am the Lord thy God, and will destroy her if she abide not in my law.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 132:55",
+							"text": "But if she will not abide this commandment, then shall my servant Joseph do all things for her, even as he hath said; and I will bless him and multiply him and give unto him an hundred-fold in this world, of fathers and mothers, brothers and sisters, houses and lands, wives and children, and crowns of eternal lives in the eternal worlds.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 132:56",
+							"text": "And again, verily I say, let mine handmaid forgive my servant Joseph his trespasses; and then shall she be forgiven her trespasses, wherein she has trespassed against me; and I, the Lord thy God, will bless her, and multiply her, and make her heart to rejoice.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 132:57",
+							"text": "And again, I say, let not my servant Joseph put his property out of his hands, lest an enemy come and destroy him; for Satan seeketh to destroy; for I am the Lord thy God, and he is my servant; and behold, and lo, I am with him, as I was with Abraham, thy father, even unto his exaltation and glory.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 132:58",
+							"text": "Now, as touching the law of the priesthood, there are many things pertaining thereunto.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 132:59",
+							"text": "Verily, if a man be called of my Father, as was Aaron, by mine own voice, and by the voice of him that sent me, and I have endowed him with the keys of the power of this priesthood, if he do anything in my name, and according to my law and by my word, he will not commit sin, and I will justify him.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 132:60",
+							"text": "Let no one, therefore, set on my servant Joseph; for I will justify him; for he shall do the sacrifice which I require at his hands for his transgressions, saith the Lord your God.",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 132:61",
+							"text": "And again, as pertaining to the law of the priesthood\u2014if any man espouse a virgin, and desire to espouse another, and the first give her consent, and if he espouse the second, and they are virgins, and have vowed to no other man, then is he justified; he cannot commit adultery for they are given unto him; for he cannot commit adultery with that that belongeth unto him and to no one else.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 132:62",
+							"text": "And if he have ten virgins given unto him by this law, he cannot commit adultery, for they belong to him, and they are given unto him; therefore is he justified.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 132:63",
+							"text": "But if one or either of the ten virgins, after she is espoused, shall be with another man, she has committed adultery, and shall be destroyed; for they are given unto him to multiply and replenish the earth, according to my commandment, and to fulfil the promise which was given by my Father before the foundation of the world, and for their exaltation in the eternal worlds, that they may bear the souls of men; for herein is the work of my Father continued, that he may be glorified.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 132:64",
+							"text": "And again, verily, verily, I say unto you, if any man have a wife, who holds the keys of this power, and he teaches unto her the law of my priesthood, as pertaining to these things, then shall she believe and administer unto him, or she shall be destroyed, saith the Lord your God; for I will destroy her; for I will magnify my name upon all those who receive and abide in my law.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 132:65",
+							"text": "Therefore, it shall be lawful in me, if she receive not this law, for him to receive all things whatsoever I, the Lord his God, will give unto him, because she did not believe and administer unto him according to my word; and she then becomes the transgressor; and he is exempt from the law of Sarah, who administered unto Abraham according to the law when I commanded Abraham to take Hagar to wife.",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 132:66",
+							"text": "And now, as pertaining to this law, verily, verily, I say unto you, I will reveal more unto you, hereafter; therefore, let this suffice for the present. Behold, I am Alpha and Omega. Amen.",
+							"verse": 66
+						}
+					]
+				},
+				{
+					"chapter": 133,
+					"reference": "D&C 133",
+					"verses": [{
+							"reference": "D&C 133:1",
+							"text": "Hearken, O ye people of my church, saith the Lord your God, and hear the word of the Lord concerning you\u2014",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 133:2",
+							"text": "The Lord who shall suddenly come to his temple; the Lord who shall come down upon the world with a curse to judgment; yea, upon all the nations that forget God, and upon all the ungodly among you.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 133:3",
+							"text": "For he shall make bare his holy arm in the eyes of all the nations, and all the ends of the earth shall see the salvation of their God.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 133:4",
+							"text": "Wherefore, prepare ye, prepare ye, O my people; sanctify yourselves; gather ye together, O ye people of my church, upon the land of Zion, all you that have not been commanded to tarry.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 133:5",
+							"text": "Go ye out from Babylon. Be ye clean that bear the vessels of the Lord.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 133:6",
+							"text": "Call your solemn assemblies, and speak often one to another. And let every man call upon the name of the Lord.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 133:7",
+							"text": "Yea, verily I say unto you again, the time has come when the voice of the Lord is unto you: Go ye out of Babylon; gather ye out from among the nations, from the four winds, from one end of heaven to the other.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 133:8",
+							"text": "Send forth the elders of my church unto the nations which are afar off; unto the islands of the sea; send forth unto foreign lands; call upon all nations, first upon the Gentiles, and then upon the Jews.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 133:9",
+							"text": "And behold, and lo, this shall be their cry, and the voice of the Lord unto all people: Go ye forth unto the land of Zion, that the borders of my people may be enlarged, and that her stakes may be strengthened, and that Zion may go forth unto the regions round about.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 133:10",
+							"text": "Yea, let the cry go forth among all people: Awake and arise and go forth to meet the Bridegroom; behold and lo, the Bridegroom cometh; go ye out to meet him. Prepare yourselves for the great day of the Lord.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 133:11",
+							"text": "Watch, therefore, for ye know neither the day nor the hour.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 133:12",
+							"text": "Let them, therefore, who are among the Gentiles flee unto Zion.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 133:13",
+							"text": "And let them who be of Judah flee unto Jerusalem, unto the mountains of the Lord's house.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 133:14",
+							"text": "Go ye out from among the nations, even from Babylon, from the midst of wickedness, which is spiritual Babylon.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 133:15",
+							"text": "But verily, thus saith the Lord, let not your flight be in haste, but let all things be prepared before you; and he that goeth, let him not look back lest sudden destruction shall come upon him.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 133:16",
+							"text": "Hearken and hear, O ye inhabitants of the earth. Listen, ye elders of my church together, and hear the voice of the Lord; for he calleth upon all men, and he commandeth all men everywhere to repent.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 133:17",
+							"text": "For behold, the Lord God hath sent forth the angel crying through the midst of heaven, saying: Prepare ye the way of the Lord, and make his paths straight, for the hour of his coming is nigh\u2014",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 133:18",
+							"text": "When the Lamb shall stand upon Mount Zion, and with him a hundred and forty-four thousand, having his Father's name written on their foreheads.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 133:19",
+							"text": "Wherefore, prepare ye for the coming of the Bridegroom; go ye, go ye out to meet him.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 133:20",
+							"text": "For behold, he shall stand upon the mount of Olivet, and upon the mighty ocean, even the great deep, and upon the islands of the sea, and upon the land of Zion.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 133:21",
+							"text": "And he shall utter his voice out of Zion, and he shall speak from Jerusalem, and his voice shall be heard among all people;",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 133:22",
+							"text": "And it shall be a voice as the voice of many waters, and as the voice of a great thunder, which shall break down the mountains, and the valleys shall not be found.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 133:23",
+							"text": "He shall command the great deep, and it shall be driven back into the north countries, and the islands shall become one land;",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 133:24",
+							"text": "And the land of Jerusalem and the land of Zion shall be turned back into their own place, and the earth shall be like as it was in the days before it was divided.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 133:25",
+							"text": "And the Lord, even the Savior, shall stand in the midst of his people, and shall reign over all flesh.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 133:26",
+							"text": "And they who are in the north countries shall come in remembrance before the Lord; and their prophets shall hear his voice, and shall no longer stay themselves; and they shall smite the rocks, and the ice shall flow down at their presence.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 133:27",
+							"text": "And an highway shall be cast up in the midst of the great deep.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 133:28",
+							"text": "Their enemies shall become a prey unto them,",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 133:29",
+							"text": "And in the barren deserts there shall come forth pools of living water; and the parched ground shall no longer be a thirsty land.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 133:30",
+							"text": "And they shall bring forth their rich treasures unto the children of Ephraim, my servants.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 133:31",
+							"text": "And the boundaries of the everlasting hills shall tremble at their presence.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 133:32",
+							"text": "And there shall they fall down and be crowned with glory, even in Zion, by the hands of the servants of the Lord, even the children of Ephraim.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 133:33",
+							"text": "And they shall be filled with songs of everlasting joy.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 133:34",
+							"text": "Behold, this is the blessing of the everlasting God upon the tribes of Israel, and the richer blessing upon the head of Ephraim and his fellows.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 133:35",
+							"text": "And they also of the tribe of Judah, after their pain, shall be sanctified in holiness before the Lord, to dwell in his presence day and night, forever and ever.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 133:36",
+							"text": "And now, verily saith the Lord, that these things might be known among you, O inhabitants of the earth, I have sent forth mine angel flying through the midst of heaven, having the everlasting gospel, who hath appeared unto some and hath committed it unto man, who shall appear unto many that dwell on the earth.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 133:37",
+							"text": "And this gospel shall be preached unto every nation, and kindred, and tongue, and people.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 133:38",
+							"text": "And the servants of God shall go forth, saying with a loud voice: Fear God and give glory to him, for the hour of his judgment is come;",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 133:39",
+							"text": "And worship him that made heaven, and earth, and the sea, and the fountains of waters\u2014",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 133:40",
+							"text": "Calling upon the name of the Lord day and night, saying: O that thou wouldst rend the heavens, that thou wouldst come down, that the mountains might flow down at thy presence.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 133:41",
+							"text": "And it shall be answered upon their heads; for the presence of the Lord shall be as the melting fire that burneth, and as the fire which causeth the waters to boil.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 133:42",
+							"text": "O Lord, thou shalt come down to make thy name known to thine adversaries, and all nations shall tremble at thy presence\u2014",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 133:43",
+							"text": "When thou doest terrible things, things they look not for;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 133:44",
+							"text": "Yea, when thou comest down, and the mountains flow down at thy presence, thou shalt meet him who rejoiceth and worketh righteousness, who remembereth thee in thy ways.",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 133:45",
+							"text": "For since the beginning of the world have not men heard nor perceived by the ear, neither hath any eye seen, O God, besides thee, how great things thou hast prepared for him that waiteth for thee.",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 133:46",
+							"text": "And it shall be said: Who is this that cometh down from God in heaven with dyed garments; yea, from the regions which are not known, clothed in his glorious apparel, traveling in the greatness of his strength?",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 133:47",
+							"text": "And he shall say: I am he who spake in righteousness, mighty to save.",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 133:48",
+							"text": "And the Lord shall be red in his apparel, and his garments like him that treadeth in the wine-vat.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 133:49",
+							"text": "And so great shall be the glory of his presence that the sun shall hide his face in shame, and the moon shall withhold its light, and the stars shall be hurled from their places.",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 133:50",
+							"text": "And his voice shall be heard: I have trodden the wine-press alone, and have brought judgment upon all people; and none were with me;",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 133:51",
+							"text": "And I have trampled them in my fury, and I did tread upon them in mine anger, and their blood have I sprinkled upon my garments, and stained all my raiment; for this was the day of vengeance which was in my heart.",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 133:52",
+							"text": "And now the year of my redeemed is come; and they shall mention the loving kindness of their Lord, and all that he has bestowed upon them according to his goodness, and according to his loving kindness, forever and ever.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 133:53",
+							"text": "In all their afflictions he was afflicted. And the angel of his presence saved them; and in his love, and in his pity, he redeemed them, and bore them, and carried them all the days of old;",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 133:54",
+							"text": "Yea, and Enoch also, and they who were with him; the prophets who were before him; and Noah also, and they who were before him; and Moses also, and they who were before him;",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 133:55",
+							"text": "And from Moses to Elijah, and from Elijah to John, who were with Christ in his resurrection, and the holy apostles, with Abraham, Isaac, and Jacob, shall be in the presence of the Lamb.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 133:56",
+							"text": "And the graves of the saints shall be opened; and they shall come forth and stand on the right hand of the Lamb, when he shall stand upon Mount Zion, and upon the holy city, the New Jerusalem; and they shall sing the song of the Lamb, day and night forever and ever.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 133:57",
+							"text": "And for this cause, that men might be made partakers of the glories which were to be revealed, the Lord sent forth the fulness of his gospel, his everlasting covenant, reasoning in plainness and simplicity\u2014",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 133:58",
+							"text": "To prepare the weak for those things which are coming on the earth, and for the Lord's errand in the day when the weak shall confound the wise, and the little one become a strong nation, and two shall put their tens of thousands to flight.",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 133:59",
+							"text": "And by the weak things of the earth the Lord shall thresh the nations by the power of his Spirit.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 133:60",
+							"text": "And for this cause these commandments were given; they were commanded to be kept from the world in the day that they were given, but now are to go forth unto all flesh\u2014",
+							"verse": 60
+						},
+						{
+							"reference": "D&C 133:61",
+							"text": "And this according to the mind and will of the Lord, who ruleth over all flesh.",
+							"verse": 61
+						},
+						{
+							"reference": "D&C 133:62",
+							"text": "And unto him that repenteth and sanctifieth himself before the Lord shall be given eternal life.",
+							"verse": 62
+						},
+						{
+							"reference": "D&C 133:63",
+							"text": "And upon them that hearken not to the voice of the Lord shall be fulfilled that which was written by the prophet Moses, that they should be cut off from among the people.",
+							"verse": 63
+						},
+						{
+							"reference": "D&C 133:64",
+							"text": "And also that which was written by the prophet Malachi: For, behold, the day cometh that shall burn as an oven, and all the proud, yea, and all that do wickedly, shall be stubble; and the day that cometh shall burn them up, saith the Lord of hosts, that it shall leave them neither root nor branch.",
+							"verse": 64
+						},
+						{
+							"reference": "D&C 133:65",
+							"text": "Wherefore, this shall be the answer of the Lord unto them:",
+							"verse": 65
+						},
+						{
+							"reference": "D&C 133:66",
+							"text": "In that day when I came unto mine own, no man among you received me, and you were driven out.",
+							"verse": 66
+						},
+						{
+							"reference": "D&C 133:67",
+							"text": "When I called again there was none of you to answer; yet my arm was not shortened at all that I could not redeem, neither my power to deliver.",
+							"verse": 67
+						},
+						{
+							"reference": "D&C 133:68",
+							"text": "Behold, at my rebuke I dry up the sea. I make the rivers a wilderness; their fish stink, and die for thirst.",
+							"verse": 68
+						},
+						{
+							"reference": "D&C 133:69",
+							"text": "I clothe the heavens with blackness, and make sackcloth their covering.",
+							"verse": 69
+						},
+						{
+							"reference": "D&C 133:70",
+							"text": "And this shall ye have of my hand\u2014ye shall lie down in sorrow.",
+							"verse": 70
+						},
+						{
+							"reference": "D&C 133:71",
+							"text": "Behold, and lo, there are none to deliver you; for ye obeyed not my voice when I called to you out of the heavens; ye believed not my servants, and when they were sent unto you ye received them not.",
+							"verse": 71
+						},
+						{
+							"reference": "D&C 133:72",
+							"text": "Wherefore, they sealed up the testimony and bound up the law, and ye were delivered over unto darkness.",
+							"verse": 72
+						},
+						{
+							"reference": "D&C 133:73",
+							"text": "These shall go away into outer darkness, where there is weeping, and wailing, and gnashing of teeth.",
+							"verse": 73
+						},
+						{
+							"reference": "D&C 133:74",
+							"text": "Behold the Lord your God hath spoken it. Amen.",
+							"verse": 74
+						}
+					]
+				},
+				{
+					"chapter": 134,
+					"reference": "D&C 134",
+					"verses": [{
+							"reference": "D&C 134:1",
+							"text": "We believe that governments were instituted of God for the benefit of man; and that he holds men accountable for their acts in relation to them, both in making laws and administering them, for the good and safety of society.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 134:2",
+							"text": "We believe that no government can exist in peace, except such laws are framed and held inviolate as will secure to each individual the free exercise of conscience, the right and control of property, and the protection of life.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 134:3",
+							"text": "We believe that all governments necessarily require civil officers and magistrates to enforce the laws of the same; and that such as will administer the law in equity and justice should be sought for and upheld by the voice of the people if a republic, or the will of the sovereign.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 134:4",
+							"text": "We believe that religion is instituted of God; and that men are amenable to him, and to him only, for the exercise of it, unless their religious opinions prompt them to infringe upon the rights and liberties of others; but we do not believe that human law has a right to interfere in prescribing rules of worship to bind the consciences of men, nor dictate forms for public or private devotion; that the civil magistrate should restrain crime, but never control conscience; should punish guilt, but never suppress the freedom of the soul.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 134:5",
+							"text": "We believe that all men are bound to sustain and uphold the respective governments in which they reside, while protected in their inherent and inalienable rights by the laws of such governments; and that sedition and rebellion are unbecoming every citizen thus protected, and should be punished accordingly; and that all governments have a right to enact such laws as in their own judgments are best calculated to secure the public interest; at the same time, however, holding sacred the freedom of conscience.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 134:6",
+							"text": "We believe that every man should be honored in his station, rulers and magistrates as such, being placed for the protection of the innocent and the punishment of the guilty; and that to the laws all men owe respect and deference, as without them peace and harmony would be supplanted by anarchy and terror; human laws being instituted for the express purpose of regulating our interests as individuals and nations, between man and man; and divine laws given of heaven, prescribing rules on spiritual concerns, for faith and worship, both to be answered by man to his Maker.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 134:7",
+							"text": "We believe that rulers, states, and governments have a right, and are bound to enact laws for the protection of all citizens in the free exercise of their religious belief; but we do not believe that they have a right in justice to deprive citizens of this privilege, or proscribe them in their opinions, so long as a regard and reverence are shown to the laws and such religious opinions do not justify sedition nor conspiracy.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 134:8",
+							"text": "We believe that the commission of crime should be punished according to the nature of the offense; that murder, treason, robbery, theft, and the breach of the general peace, in all respects, should be punished according to their criminality and their tendency to evil among men, by the laws of that government in which the offense is committed; and for the public peace and tranquility all men should step forward and use their ability in bringing offenders against good laws to punishment.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 134:9",
+							"text": "We do not believe it just to mingle religious influence with civil government, whereby one religious society is fostered and another proscribed in its spiritual privileges, and the individual rights of its members, as citizens, denied.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 134:10",
+							"text": "We believe that all religious societies have a right to deal with their members for disorderly conduct, according to the rules and regulations of such societies; provided that such dealings be for fellowship and good standing; but we do not believe that any religious society has authority to try men on the right of property or life, to take from them this world's goods, or to put them in jeopardy of either life or limb, or to inflict any physical punishment upon them. They can only excommunicate them from their society, and withdraw from them their fellowship.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 134:11",
+							"text": "We believe that men should appeal to the civil law for redress of all wrongs and grievances, where personal abuse is inflicted or the right of property or character infringed, where such laws exist as will protect the same; but we believe that all men are justified in defending themselves, their friends, and property, and the government, from the unlawful assaults and encroachments of all persons in times of exigency, where immediate appeal cannot be made to the laws, and relief afforded.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 134:12",
+							"text": "We believe it just to preach the gospel to the nations of the earth, and warn the righteous to save themselves from the corruption of the world; but we do not believe it right to interfere with bond-servants, neither preach the gospel to, nor baptize them contrary to the will and wish of their masters, nor to meddle with or influence them in the least to cause them to be dissatisfied with their situations in this life, thereby jeopardizing the lives of men; such interference we believe to be unlawful and unjust, and dangerous to the peace of every government allowing human beings to be held in servitude.",
+							"verse": 12
+						}
+					]
+				},
+				{
+					"chapter": 135,
+					"reference": "D&C 135",
+					"verses": [{
+							"reference": "D&C 135:1",
+							"text": "To seal the testimony of this book and the Book of Mormon, we announce the martyrdom of Joseph Smith the Prophet, and Hyrum Smith the Patriarch. They were shot in Carthage jail, on the 27th of June, 1844, about five o'clock p.m., by an armed mob\u2014painted black\u2014of from 150 to 200 persons. Hyrum was shot first and fell calmly, exclaiming: I am a dead man! Joseph leaped from the window, and was shot dead in the attempt, exclaiming: O Lord my God! They were both shot after they were dead, in a brutal manner, and both received four balls.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 135:2",
+							"text": "John Taylor and Willard Richards, two of the Twelve, were the only persons in the room at the time; the former was wounded in a savage manner with four balls, but has since recovered; the latter, through the providence of God, escaped, without even a hole in his robe.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 135:3",
+							"text": "Joseph Smith, the Prophet and Seer of the Lord, has done more, save Jesus only, for the salvation of men in this world, than any other man that ever lived in it. In the short space of twenty years, he has brought forth the Book of Mormon, which he translated by the gift and power of God, and has been the means of publishing it on two continents; has sent the fulness of the everlasting gospel, which it contained, to the four quarters of the earth; has brought forth the revelations and commandments which compose this book of Doctrine and Covenants, and many other wise documents and instructions for the benefit of the children of men; gathered many thousands of the Latter-day Saints, founded a great city, and left a fame and name that cannot be slain. He lived great, and he died great in the eyes of God and his people; and like most of the Lord's anointed in ancient times, has sealed his mission and his works with his own blood; and so has his brother Hyrum. In life they were not divided, and in death they were not separated!",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 135:4",
+							"text": "When Joseph went to Carthage to deliver himself up to the pretended requirements of the law, two or three days previous to his assassination, he said: \"I am going like a lamb to the slaughter; but I am calm as a summer's morning; I have a conscience void of offense towards God, and towards all men. I SHALL DIE INNOCENT, AND IT SHALL YET BE SAID OF ME\u2014HE WAS MURDERED IN COLD BLOOD.\"\u2014The same morning, after Hyrum had made ready to go\u2014shall it be said to the slaughter? yes, for so it was\u2014he read the following paragraph, near the close of the twelfth chapter of Ether, in the Book of Mormon, and turned down the leaf upon it:",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 135:5",
+							"text": "And it came to pass that I prayed unto the Lord that he would give unto the Gentiles grace, that they might have charity. And it came to pass that the Lord said unto me: If they have not charity it mattereth not unto thee, thou hast been faithful; wherefore thy garments shall be made clean. And because thou hast seen thy weakness, thou shalt be made strong, even unto the sitting down in the place which I have prepared in the mansions of my Father. And now I . . . bid farewell unto the Gentiles; yea, and also unto my brethren whom I love, until we shall meet before the judgment-seat of Christ, where all men shall know that my garments are not spotted with your blood. The testators are now dead, and their testament is in force.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 135:6",
+							"text": "Hyrum Smith was forty-four years old in February, 1844, and Joseph Smith was thirty-eight in December, 1843; and henceforward their names will be classed among the martyrs of religion; and the reader in every nation will be reminded that the Book of Mormon, and this book of Doctrine and Covenants of the church, cost the best blood of the nineteenth century to bring them forth for the salvation of a ruined world; and that if the fire can scathe a green tree for the glory of God, how easy it will burn up the dry trees to purify the vineyard of corruption. They lived for glory; they died for glory; and glory is their eternal reward. From age to age shall their names go down to posterity as gems for the sanctified.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 135:7",
+							"text": "They were innocent of any crime, as they had often been proved before, and were only confined in jail by the conspiracy of traitors and wicked men; and their innocent blood on the floor of Carthage jail is a broad seal affixed to \"Mormonism\" that cannot be rejected by any court on earth, and their innocent blood on the escutcheon of the State of Illinois, with the broken faith of the State as pledged by the governor, is a witness to the truth of the everlasting gospel that all the world cannot impeach; and their innocent blood on the banner of liberty, and on the magna charta of the United States, is an ambassador for the religion of Jesus Christ, that will touch the hearts of honest men among all nations; and their innocent blood, with the innocent blood of all the martyrs under the altar that John saw, will cry unto the Lord of Hosts till he avenges that blood on the earth. Amen.",
+							"verse": 7
+						}
+					]
+				},
+				{
+					"chapter": 136,
+					"reference": "D&C 136",
+					"verses": [{
+							"reference": "D&C 136:1",
+							"text": "The Word and Will of the Lord concerning the Camp of Israel in their journeyings to the West:",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 136:2",
+							"text": "Let all the people of The Church of Jesus Christ of Latter-day Saints, and those who journey with them, be organized into companies, with a covenant and promise to keep all the commandments and statutes of the Lord our God.",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 136:3",
+							"text": "Let the companies be organized with captains of hundreds, captains of fifties, and captains of tens, with a president and his two counselors at their head, under the direction of the Twelve Apostles.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 136:4",
+							"text": "And this shall be our covenant\u2014that we will walk in all the ordinances of the Lord.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 136:5",
+							"text": "Let each company provide themselves with all the teams, wagons, provisions, clothing, and other necessaries for the journey, that they can.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 136:6",
+							"text": "When the companies are organized let them go to with their might, to prepare for those who are to tarry.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 136:7",
+							"text": "Let each company, with their captains and presidents, decide how many can go next spring; then choose out a sufficient number of able-bodied and expert men, to take teams, seeds, and farming utensils, to go as pioneers to prepare for putting in spring crops.",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 136:8",
+							"text": "Let each company bear an equal proportion, according to the dividend of their property, in taking the poor, the widows, the fatherless, and the families of those who have gone into the army, that the cries of the widow and the fatherless come not up into the ears of the Lord against this people.",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 136:9",
+							"text": "Let each company prepare houses, and fields for raising grain, for those who are to remain behind this season; and this is the will of the Lord concerning his people.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 136:10",
+							"text": "Let every man use all his influence and property to remove this people to the place where the Lord shall locate a stake of Zion.",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 136:11",
+							"text": "And if ye do this with a pure heart, in all faithfulness, ye shall be blessed; you shall be blessed in your flocks, and in your herds, and in your fields, and in your houses, and in your families.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 136:12",
+							"text": "Let my servants Ezra T. Benson and Erastus Snow organize a company.",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 136:13",
+							"text": "And let my servants Orson Pratt and Wilford Woodruff organize a company.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 136:14",
+							"text": "Also, let my servants Amasa Lyman and George A. Smith organize a company.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 136:15",
+							"text": "And appoint presidents, and captains of hundreds, and of fifties, and of tens.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 136:16",
+							"text": "And let my servants that have been appointed go and teach this, my will, to the saints, that they may be ready to go to a land of peace.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 136:17",
+							"text": "Go thy way and do as I have told you, and fear not thine enemies; for they shall not have power to stop my work.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 136:18",
+							"text": "Zion shall be redeemed in mine own due time.",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 136:19",
+							"text": "And if any man shall seek to build up himself, and seeketh not my counsel, he shall have no power, and his folly shall be made manifest.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 136:20",
+							"text": "Seek ye; and keep all your pledges one with another; and covet not that which is thy brother's.",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 136:21",
+							"text": "Keep yourselves from evil to take the name of the Lord in vain, for I am the Lord your God, even the God of your fathers, the God of Abraham and of Isaac and of Jacob.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 136:22",
+							"text": "I am he who led the children of Israel out of the land of Egypt; and my arm is stretched out in the last days, to save my people Israel.",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 136:23",
+							"text": "Cease to contend one with another; cease to speak evil one of another.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 136:24",
+							"text": "Cease drunkenness; and let your words tend to edifying one another.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 136:25",
+							"text": "If thou borrowest of thy neighbor, thou shalt restore that which thou hast borrowed; and if thou canst not repay then go straightway and tell thy neighbor, lest he condemn thee.",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 136:26",
+							"text": "If thou shalt find that which thy neighbor has lost, thou shalt make diligent search till thou shalt deliver it to him again.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 136:27",
+							"text": "Thou shalt be diligent in preserving what thou hast, that thou mayest be a wise steward; for it is the free gift of the Lord thy God, and thou art his steward.",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 136:28",
+							"text": "If thou art merry, praise the Lord with singing, with music, with dancing, and with a prayer of praise and thanksgiving.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 136:29",
+							"text": "If thou art sorrowful, call on the Lord thy God with supplication, that your souls may be joyful.",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 136:30",
+							"text": "Fear not thine enemies, for they are in mine hands and I will do my pleasure with them.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 136:31",
+							"text": "My people must be tried in all things, that they may be prepared to receive the glory that I have for them, even the glory of Zion; and he that will not bear chastisement is not worthy of my kingdom.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 136:32",
+							"text": "Let him that is ignorant learn wisdom by humbling himself and calling upon the Lord his God, that his eyes may be opened that he may see, and his ears opened that he may hear;",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 136:33",
+							"text": "For my Spirit is sent forth into the world to enlighten the humble and contrite, and to the condemnation of the ungodly.",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 136:34",
+							"text": "Thy brethren have rejected you and your testimony, even the nation that has driven you out;",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 136:35",
+							"text": "And now cometh the day of their calamity, even the days of sorrow, like a woman that is taken in travail; and their sorrow shall be great unless they speedily repent, yea, very speedily.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 136:36",
+							"text": "For they killed the prophets, and them that were sent unto them; and they have shed innocent blood, which crieth from the ground against them.",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 136:37",
+							"text": "Therefore, marvel not at these things, for ye are not yet pure; ye can not yet bear my glory; but ye shall behold it if ye are faithful in keeping all my words that I have given you, from the days of Adam to Abraham, from Abraham to Moses, from Moses to Jesus and his apostles, and from Jesus and his apostles to Joseph Smith, whom I did call upon by mine angels, my ministering servants, and by mine own voice out of the heavens, to bring forth my work;",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 136:38",
+							"text": "Which foundation he did lay, and was faithful; and I took him to myself.",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 136:39",
+							"text": "Many have marveled because of his death; but it was needful that he should seal his testimony with his blood, that he might be honored and the wicked might be condemned.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 136:40",
+							"text": "Have I not delivered you from your enemies, only in that I have left a witness of my name?",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 136:41",
+							"text": "Now, therefore, hearken, O ye people of my church; and ye elders listen together; you have received my kingdom.",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 136:42",
+							"text": "Be diligent in keeping all my commandments, lest judgments come upon you, and your faith fail you, and your enemies triumph over you. So no more at present. Amen and Amen.",
+							"verse": 42
+						}
+					]
+				},
+				{
+					"chapter": 137,
+					"reference": "D&C 137",
+					"verses": [{
+							"reference": "D&C 137:1",
+							"text": "The heavens were opened upon us, and I beheld the celestial kingdom of God, and the glory thereof, whether in the body or out I cannot tell.",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 137:2",
+							"text": "I saw the transcendent beauty of the gate through which the heirs of that kingdom will enter, which was like unto circling flames of fire;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 137:3",
+							"text": "Also the blazing throne of God, whereon was seated the Father and the Son.",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 137:4",
+							"text": "I saw the beautiful streets of that kingdom, which had the appearance of being paved with gold.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 137:5",
+							"text": "I saw Father Adam and Abraham; and my father and my mother; my brother Alvin, that has long since slept;",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 137:6",
+							"text": "And marveled how it was that he had obtained an inheritance in that kingdom, seeing that he had departed this life before the Lord had set his hand to gather Israel the second time, and had not been baptized for the remission of sins.",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 137:7",
+							"text": "Thus came the voice of the Lord unto me, saying: All who have died without a knowledge of this gospel, who would have received it if they had been permitted to tarry, shall be heirs of the celestial kingdom of God;",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 137:8",
+							"text": "Also all that shall die henceforth without a knowledge of it, who would have received it with all their hearts, shall be heirs of that kingdom;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 137:9",
+							"text": "For I, the Lord, will judge all men according to their works, according to the desire of their hearts.",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 137:10",
+							"text": "And I also beheld that all children who die before they arrive at the years of accountability are saved in the celestial kingdom of heaven.",
+							"verse": 10
+						}
+					]
+				},
+				{
+					"chapter": 138,
+					"reference": "D&C 138",
+					"verses": [{
+							"reference": "D&C 138:1",
+							"text": "On the third of October, in the year nineteen hundred and eighteen, I sat in my room pondering over the scriptures;",
+							"verse": 1
+						},
+						{
+							"reference": "D&C 138:2",
+							"text": "And reflecting upon the great atoning sacrifice that was made by the Son of God, for the redemption of the world;",
+							"verse": 2
+						},
+						{
+							"reference": "D&C 138:3",
+							"text": "And the great and wonderful love made manifest by the Father and the Son in the coming of the Redeemer into the world;",
+							"verse": 3
+						},
+						{
+							"reference": "D&C 138:4",
+							"text": "That through his atonement, and by obedience to the principles of the gospel, mankind might be saved.",
+							"verse": 4
+						},
+						{
+							"reference": "D&C 138:5",
+							"text": "While I was thus engaged, my mind reverted to the writings of the apostle Peter, to the primitive saints scattered abroad throughout Pontus, Galatia, Cappadocia, and other parts of Asia, where the gospel had been preached after the crucifixion of the Lord.",
+							"verse": 5
+						},
+						{
+							"reference": "D&C 138:6",
+							"text": "I opened the Bible and read the third and fourth chapters of the first epistle of Peter, and as I read I was greatly impressed, more than I had ever been before, with the following passages:",
+							"verse": 6
+						},
+						{
+							"reference": "D&C 138:7",
+							"text": "\"For Christ also hath once suffered for sins, the just for the unjust, that he might bring us to God, being put to death in the flesh, but quickened by the Spirit:",
+							"verse": 7
+						},
+						{
+							"reference": "D&C 138:8",
+							"text": "\"By which also he went and preached unto the spirits in prison;",
+							"verse": 8
+						},
+						{
+							"reference": "D&C 138:9",
+							"text": "\"Which sometime were disobedient, when once the longsuffering of God waited in the days of Noah, while the ark was a preparing, wherein few, that is, eight souls were saved by water.\" (1 Peter 3:18\u201320.)",
+							"verse": 9
+						},
+						{
+							"reference": "D&C 138:10",
+							"text": "\"For for this cause was the gospel preached also to them that are dead, that they might be judged according to men in the flesh, but live according to God in the spirit.\" (1 Peter 4:6.)",
+							"verse": 10
+						},
+						{
+							"reference": "D&C 138:11",
+							"text": "As I pondered over these things which are written, the eyes of my understanding were opened, and the Spirit of the Lord rested upon me, and I saw the hosts of the dead, both small and great.",
+							"verse": 11
+						},
+						{
+							"reference": "D&C 138:12",
+							"text": "And there were gathered together in one place an innumerable company of the spirits of the just, who had been faithful in the testimony of Jesus while they lived in mortality;",
+							"verse": 12
+						},
+						{
+							"reference": "D&C 138:13",
+							"text": "And who had offered sacrifice in the similitude of the great sacrifice of the Son of God, and had suffered tribulation in their Redeemer's name.",
+							"verse": 13
+						},
+						{
+							"reference": "D&C 138:14",
+							"text": "All these had departed the mortal life, firm in the hope of a glorious resurrection, through the grace of God the Father and his Only Begotten Son, Jesus Christ.",
+							"verse": 14
+						},
+						{
+							"reference": "D&C 138:15",
+							"text": "I beheld that they were filled with joy and gladness, and were rejoicing together because the day of their deliverance was at hand.",
+							"verse": 15
+						},
+						{
+							"reference": "D&C 138:16",
+							"text": "They were assembled awaiting the advent of the Son of God into the spirit world, to declare their redemption from the bands of death.",
+							"verse": 16
+						},
+						{
+							"reference": "D&C 138:17",
+							"text": "Their sleeping dust was to be restored unto its perfect frame, bone to his bone, and the sinews and the flesh upon them, the spirit and the body to be united never again to be divided, that they might receive a fulness of joy.",
+							"verse": 17
+						},
+						{
+							"reference": "D&C 138:18",
+							"text": "While this vast multitude waited and conversed, rejoicing in the hour of their deliverance from the chains of death, the Son of God appeared, declaring liberty to the captives who had been faithful;",
+							"verse": 18
+						},
+						{
+							"reference": "D&C 138:19",
+							"text": "And there he preached to them the everlasting gospel, the doctrine of the resurrection and the redemption of mankind from the fall, and from individual sins on conditions of repentance.",
+							"verse": 19
+						},
+						{
+							"reference": "D&C 138:20",
+							"text": "But unto the wicked he did not go, and among the ungodly and the unrepentant who had defiled themselves while in the flesh, his voice was not raised;",
+							"verse": 20
+						},
+						{
+							"reference": "D&C 138:21",
+							"text": "Neither did the rebellious who rejected the testimonies and the warnings of the ancient prophets behold his presence, nor look upon his face.",
+							"verse": 21
+						},
+						{
+							"reference": "D&C 138:22",
+							"text": "Where these were, darkness reigned, but among the righteous there was peace;",
+							"verse": 22
+						},
+						{
+							"reference": "D&C 138:23",
+							"text": "And the saints rejoiced in their redemption, and bowed the knee and acknowledged the Son of God as their Redeemer and Deliverer from death and the chains of hell.",
+							"verse": 23
+						},
+						{
+							"reference": "D&C 138:24",
+							"text": "Their countenances shone, and the radiance from the presence of the Lord rested upon them, and they sang praises unto his holy name.",
+							"verse": 24
+						},
+						{
+							"reference": "D&C 138:25",
+							"text": "I marveled, for I understood that the Savior spent about three years in his ministry among the Jews and those of the house of Israel, endeavoring to teach them the everlasting gospel and call them unto repentance;",
+							"verse": 25
+						},
+						{
+							"reference": "D&C 138:26",
+							"text": "And yet, notwithstanding his mighty works, and miracles, and proclamation of the truth, in great power and authority, there were but few who hearkened to his voice, and rejoiced in his presence, and received salvation at his hands.",
+							"verse": 26
+						},
+						{
+							"reference": "D&C 138:27",
+							"text": "But his ministry among those who were dead was limited to the brief time intervening between the crucifixion and his resurrection;",
+							"verse": 27
+						},
+						{
+							"reference": "D&C 138:28",
+							"text": "And I wondered at the words of Peter\u2014wherein he said that the Son of God preached unto the spirits in prison, who sometime were disobedient, when once the long-suffering of God waited in the days of Noah\u2014and how it was possible for him to preach to those spirits and perform the necessary labor among them in so short a time.",
+							"verse": 28
+						},
+						{
+							"reference": "D&C 138:29",
+							"text": "And as I wondered, my eyes were opened, and my understanding quickened, and I perceived that the Lord went not in person among the wicked and the disobedient who had rejected the truth, to teach them;",
+							"verse": 29
+						},
+						{
+							"reference": "D&C 138:30",
+							"text": "But behold, from among the righteous, he organized his forces and appointed messengers, clothed with power and authority, and commissioned them to go forth and carry the light of the gospel to them that were in darkness, even to all the spirits of men; and thus was the gospel preached to the dead.",
+							"verse": 30
+						},
+						{
+							"reference": "D&C 138:31",
+							"text": "And the chosen messengers went forth to declare the acceptable day of the Lord and proclaim liberty to the captives who were bound, even unto all who would repent of their sins and receive the gospel.",
+							"verse": 31
+						},
+						{
+							"reference": "D&C 138:32",
+							"text": "Thus was the gospel preached to those who had died in their sins, without a knowledge of the truth, or in transgression, having rejected the prophets.",
+							"verse": 32
+						},
+						{
+							"reference": "D&C 138:33",
+							"text": "These were taught faith in God, repentance from sin, vicarious baptism for the remission of sins, the gift of the Holy Ghost by the laying on of hands,",
+							"verse": 33
+						},
+						{
+							"reference": "D&C 138:34",
+							"text": "And all other principles of the gospel that were necessary for them to know in order to qualify themselves that they might be judged according to men in the flesh, but live according to God in the spirit.",
+							"verse": 34
+						},
+						{
+							"reference": "D&C 138:35",
+							"text": "And so it was made known among the dead, both small and great, the unrighteous as well as the faithful, that redemption had been wrought through the sacrifice of the Son of God upon the cross.",
+							"verse": 35
+						},
+						{
+							"reference": "D&C 138:36",
+							"text": "Thus was it made known that our Redeemer spent his time during his sojourn in the world of spirits, instructing and preparing the faithful spirits of the prophets who had testified of him in the flesh;",
+							"verse": 36
+						},
+						{
+							"reference": "D&C 138:37",
+							"text": "That they might carry the message of redemption unto all the dead, unto whom he could not go personally, because of their rebellion and transgression, that they through the ministration of his servants might also hear his words.",
+							"verse": 37
+						},
+						{
+							"reference": "D&C 138:38",
+							"text": "Among the great and mighty ones who were assembled in this vast congregation of the righteous were Father Adam, the Ancient of Days and father of all,",
+							"verse": 38
+						},
+						{
+							"reference": "D&C 138:39",
+							"text": "And our glorious Mother Eve, with many of her faithful daughters who had lived through the ages and worshiped the true and living God.",
+							"verse": 39
+						},
+						{
+							"reference": "D&C 138:40",
+							"text": "Abel, the first martyr, was there, and his brother Seth, one of the mighty ones, who was in the express image of his father, Adam.",
+							"verse": 40
+						},
+						{
+							"reference": "D&C 138:41",
+							"text": "Noah, who gave warning of the flood; Shem, the great high priest; Abraham, the father of the faithful; Isaac, Jacob, and Moses, the great law-giver of Israel;",
+							"verse": 41
+						},
+						{
+							"reference": "D&C 138:42",
+							"text": "And Isaiah, who declared by prophecy that the Redeemer was anointed to bind up the broken-hearted, to proclaim liberty to the captives, and the opening of the prison to them that were bound, were also there.",
+							"verse": 42
+						},
+						{
+							"reference": "D&C 138:43",
+							"text": "Moreover, Ezekiel, who was shown in vision the great valley of dry bones, which were to be clothed upon with flesh, to come forth again in the resurrection of the dead, living souls;",
+							"verse": 43
+						},
+						{
+							"reference": "D&C 138:44",
+							"text": "Daniel, who foresaw and foretold the establishment of the kingdom of God in the latter days, never again to be destroyed nor given to other people;",
+							"verse": 44
+						},
+						{
+							"reference": "D&C 138:45",
+							"text": "Elias, who was with Moses on the Mount of Transfiguration;",
+							"verse": 45
+						},
+						{
+							"reference": "D&C 138:46",
+							"text": "And Malachi, the prophet who testified of the coming of Elijah\u2014of whom also Moroni spake to the Prophet Joseph Smith, declaring that he should come before the ushering in of the great and dreadful day of the Lord\u2014were also there.",
+							"verse": 46
+						},
+						{
+							"reference": "D&C 138:47",
+							"text": "The Prophet Elijah was to plant in the hearts of the children the promises made to their fathers,",
+							"verse": 47
+						},
+						{
+							"reference": "D&C 138:48",
+							"text": "Foreshadowing the great work to be done in the temples of the Lord in the dispensation of the fulness of times, for the redemption of the dead, and the sealing of the children to their parents, lest the whole earth be smitten with a curse and utterly wasted at his coming.",
+							"verse": 48
+						},
+						{
+							"reference": "D&C 138:49",
+							"text": "All these and many more, even the prophets who dwelt among the Nephites and testified of the coming of the Son of God, mingled in the vast assembly and waited for their deliverance,",
+							"verse": 49
+						},
+						{
+							"reference": "D&C 138:50",
+							"text": "For the dead had looked upon the long absence of their spirits from their bodies as a bondage.",
+							"verse": 50
+						},
+						{
+							"reference": "D&C 138:51",
+							"text": "These the Lord taught, and gave them power to come forth, after his resurrection from the dead, to enter into his Father's kingdom, there to be crowned with immortality and eternal life,",
+							"verse": 51
+						},
+						{
+							"reference": "D&C 138:52",
+							"text": "And continue thenceforth their labor as had been promised by the Lord, and be partakers of all blessings which were held in reserve for them that love him.",
+							"verse": 52
+						},
+						{
+							"reference": "D&C 138:53",
+							"text": "The Prophet Joseph Smith, and my father, Hyrum Smith, Brigham Young, John Taylor, Wilford Woodruff, and other choice spirits who were reserved to come forth in the fulness of times to take part in laying the foundations of the great latter-day work,",
+							"verse": 53
+						},
+						{
+							"reference": "D&C 138:54",
+							"text": "Including the building of the temples and the performance of ordinances therein for the redemption of the dead, were also in the spirit world.",
+							"verse": 54
+						},
+						{
+							"reference": "D&C 138:55",
+							"text": "I observed that they were also among the noble and great ones who were chosen in the beginning to be rulers in the Church of God.",
+							"verse": 55
+						},
+						{
+							"reference": "D&C 138:56",
+							"text": "Even before they were born, they, with many others, received their first lessons in the world of spirits and were prepared to come forth in the due time of the Lord to labor in his vineyard for the salvation of the souls of men.",
+							"verse": 56
+						},
+						{
+							"reference": "D&C 138:57",
+							"text": "I beheld that the faithful elders of this dispensation, when they depart from mortal life, continue their labors in the preaching of the gospel of repentance and redemption, through the sacrifice of the Only Begotten Son of God, among those who are in darkness and under the bondage of sin in the great world of the spirits of the dead.",
+							"verse": 57
+						},
+						{
+							"reference": "D&C 138:58",
+							"text": "The dead who repent will be redeemed, through obedience to the ordinances of the house of God,",
+							"verse": 58
+						},
+						{
+							"reference": "D&C 138:59",
+							"text": "And after they have paid the penalty of their transgressions, and are washed clean, shall receive a reward according to their works, for they are heirs of salvation.",
+							"verse": 59
+						},
+						{
+							"reference": "D&C 138:60",
+							"text": "Thus was the vision of the redemption of the dead revealed to me, and I bear record, and I know that this record is true, through the blessing of our Lord and Savior, Jesus Christ, even so. Amen.",
+							"verse": 60
+						}
+					]
+				}
+			]
+		}
+	],
+	"subsubtitle": "Containing Revelations Given to Joseph Smith, the Prophet with Some Additions by His Successors in the Presidency of the Church",
+	"subtitle": "of The Church of Jesus Christ of Latter-day Saints",
+	"title": "The Doctrine and Covenants",
+	"version": 3
+}


### PR DESCRIPTION
This restructures a copy of the D&C json to match the same books -> chapters -> verses hierarchy as seen in the other jsons; all with the goal of facilitating parsing by making one standard parsing script work to fetch data from all included jsons. (Given that D&C is currently holds a long list of sections)

The book tag divides the json into chunks of 25 sections. (ie: 1-25, 26-50, etc.)