### PR TITLE
Text corrections for Psalms, Obadiah, D&C, and Joseph Smith—History

### DIFF
--- a/doctrine-and-covenants.json
+++ b/doctrine-and-covenants.json
@@ -18510,7 +18510,7 @@
 				},
 				{
 					"reference": "D&C 135:5",
-					"text": "And it came to pass that I prayed unto the Lord that he would give unto the Gentiles grace, that they might have charity. And it came to pass that the Lord said unto me: If they have not charity it mattereth not unto thee, thou hast been faithful; wherefore thy garments shall be made clean. And because thou hast seen thy weakness, thou shalt be made strong, even unto the sitting down in the place which I have prepared in the mansions of my Father. And now I . . . bid farewell unto the Gentiles; yea, and also unto my brethren whom I love, until we shall meet before the judgment-seat of Christ, where all men shall know that my garments are not spotted with your blood. The testators are now dead, and their testament is in force.",
+					"text": "And it came to pass that I prayed unto the Lord that he would give unto the Gentiles grace, that they might have charity. And it came to pass that the Lord said unto me: If they have not charity it mattereth not unto thee, thou hast been faithful; wherefore thy garments shall be made clean. And because thou hast seen thy weakness, thou shalt be made strong, even unto the sitting down in the place which I have prepared in the mansions of my Father. And now I … bid farewell unto the Gentiles; yea, and also unto my brethren whom I love, until we shall meet before the judgment-seat of Christ, where all men shall know that my garments are not spotted with your blood. The testators are now dead, and their testament is in force.",
 					"verse": 5
 				},
 				{

--- a/doctrine-and-covenants.json
+++ b/doctrine-and-covenants.json
@@ -1,5 +1,5 @@
 {
-	"last_modified": "2024-12-27",
+	"last_modified": "2025-05-08",
 	"lds_slug": "dc-testament/dc",
 	"sections": [
 		{
@@ -19107,5 +19107,5 @@
 	"subsubtitle": "Containing Revelations Given to Joseph Smith, the Prophet with Some Additions by His Successors in the Presidency of the Church",
 	"subtitle": "of The Church of Jesus Christ of Latter-day Saints",
 	"title": "The Doctrine and Covenants",
-	"version": 4
+	"version": 5
 }

--- a/pearl-of-great-price.json
+++ b/pearl-of-great-price.json
@@ -3368,9 +3368,9 @@
             "lds_slug": "a-of-f"
         }
     ],
-	"last_modified": "2016-10-02",
+	"last_modified": "2025-05-08",
     "lds_slug": "pgp",
 	"subtitle": "A Selection from the Revelations, Translations, and Narrations of Joseph Smith First Prophet, Seer, and Revelator to The Church of Jesus Christ of Latter-day Saints",
 	"title": "The Pearl of Great Price",
-	"version": 3
+	"version": 4
 }

--- a/pearl-of-great-price.json
+++ b/pearl-of-great-price.json
@@ -2918,7 +2918,7 @@
                         },
                         {
                             "reference": "Joseph Smith—History 1:3",
-                            "text": "I was born in the year of our Lord one thousand eight hundred and five, on the twenty-third day of December, in the town of Sharon, Windsor county, State of Vermont. …  My father, Joseph Smith, Sen., left the State of Vermont, and moved to Palmyra, Ontario (now Wayne) county, in the State of New York, when I was in my tenth year, or thereabouts. In about four years after my father's arrival in Palmyra, he moved with his family into Manchester in the same county of Ontario—",
+                            "text": "I was born in the year of our Lord one thousand eight hundred and five, on the twenty-third day of December, in the town of Sharon, Windsor county, State of Vermont. … My father, Joseph Smith, Sen., left the State of Vermont, and moved to Palmyra, Ontario (now Wayne) county, in the State of New York, when I was in my tenth year, or thereabouts. In about four years after my father's arrival in Palmyra, he moved with his family into Manchester in the same county of Ontario—",
                             "verse": 3
                         },
                         {


### PR DESCRIPTION
Fixed the following errors for better accuracy and consistency:

- Fixed capitalization in Psalm 140:7
- Added missing pilcrow tags in Obadiah
- Replaced `. . .` with the `…` character in D&C 135:5
- Removed extra space character in Joseph Smith-History 1:3
